### PR TITLE
[FEAT] 실시간 면접 SSE 연결 기능 구현

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -1,0 +1,31 @@
+package com.aibe.team2.domain.interview.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/interviews")
+public class InterviewController {
+
+    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter connect() {
+        // SSE 연결 객체 생성 (유효시간 30분)
+        SseEmitter emitter = new SseEmitter(30 * 60 * 1000L);
+
+        try {
+            // 연결 직후 데이터를 보내야 연결 유지가 됨
+            emitter.send(SseEmitter.event()
+                    .name("connect")
+                    .data("실시간 면접 세션에 연결되었습니다."));
+        } catch (IOException e) {
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+}


### PR DESCRIPTION
<!-- 제목 예시: [feat] 관리자 페이지 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 관련 이슈
- closed: #4

## 작업 내용
- 실시간 면접 진행 상태 공유를 위한 SSE(Server-Sent Events) 프로토콜 엔드포인트 구현
- InterviewController 내 /api/interviews/connect API 추가
- 클라이언트 연결 시 초기 연결 확인 메시지 전송 로직 구현 (SseEmitter 사용)

<br/>

## 변경 사항 및 주의 사항
- 패키지 위치: com.aibe.team2.domain.interview.controller 패키지가 신설
- 타임아웃: 현재 연결 유지 시간은 테스트를 위해 30분으로 설정되어 추후 서버 부하에 따라 조정이 필요
- 테스트: Swagger UI에서 해당 API를 호출하면 text/event-stream 형태의 응답이 유지되는 것을 확인할 수 있음

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #
