### PR TITLE
chore: configure local mysql and redis with docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# ======================
+# MySQL
+# ======================
+
+MYSQL_HOST=localhost
+MYSQL_PORT=3307
+
+MYSQL_DATABASE=aibe
+MYSQL_USER=aibe
+MYSQL_PASSWORD=aibe1234
+
+MYSQL_ROOT_PASSWORD=root1234
+
+
+# ======================
+# Redis
+# ======================
+
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+
+# ======================
+# JWT / Security
+# ======================
+
+# 반드시 개인별로 변경하세요
+JWT_SECRET=change-this-secret-key
+
+
+# ======================
+# AI API
+# ======================
+
+# 개인 API Key 입력
+AI_API_KEY=your-api-key-here
+
+
+# ======================
+# AWS (Deploy Later)
+# ======================
+
+AWS_ACCESS_KEY=
+AWS_SECRET_KEY=
+AWS_REGION=ap-northeast-2

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,11 @@ Thumbs.db
 *.mv.db
 *.trace.db
 
+# Env
+.env
+.env.*
+# allow example template
+!.env.example
+
 ### dev ###
 application-dev.yml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # AIBE4_FinalProject_Team2_BE
 2팀 임시 프로젝트 BE 
+
+## Local Dev (Docker Compose)
+
+### Run
+```bash
+docker compose up -d
+```
+### Stop
+```
+docker compose down
+```
+
+### Local DB
+
+Host: localhost  
+Port: 3307  
+Database: aibe  
+Username: aibe  
+Password: aibe1234

--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 
 ## Local Dev (Docker Compose)
 
+### 1. Create .env
+
+#### macOS / Linux
+```bash
+cp .env.example .env
+```
+
+#### Windows (PowerShell)
+```
+Copy-Item .env.example .env
+```
+
 ### Run
 ```bash
 docker compose up -d

--- a/compose.yml
+++ b/compose.yml
@@ -4,18 +4,18 @@ services:
     container_name: aibe-mysql
     restart: unless-stopped
     environment:
-      MYSQL_DATABASE: aibe
-      MYSQL_USER: aibe
-      MYSQL_PASSWORD: aibe1234
-      MYSQL_ROOT_PASSWORD: root1234
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       TZ: Asia/Seoul
     ports:
-      - "3307:3306"
+      - "${MYSQL_PORT:-3307}:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     command: ["mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot1234"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-p${MYSQL_ROOT_PASSWORD}"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -25,7 +25,7 @@ services:
     container_name: aibe-redis
     restart: unless-stopped
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
     command: ["redis-server", "--appendonly", "yes"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,40 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: aibe-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: aibe
+      MYSQL_USER: aibe
+      MYSQL_PASSWORD: aibe1234
+      MYSQL_ROOT_PASSWORD: root1234
+      TZ: Asia/Seoul
+    ports:
+      - "3307:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command: ["mysqld", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-proot1234"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    container_name: aibe-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    command: ["redis-server", "--appendonly", "yes"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  mysql_data:
+  redis_data:


### PR DESCRIPTION
## 관련 이슈
- closed: #12

## 작업 내용
- 로컬 개발환경용 MySQL, Redis docker-compose 구성
- MySQL 포트 충돌 방지를 위해 3307 포트 사용
- README에 실행/중단 가이드 추가

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다