### PR TITLE
[FEAT] 실시간 면접 세션 관리 및 SSE 스트리밍 엔진 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/aibe/team2/AibeApplication.java
+++ b/src/main/java/com/aibe/team2/AibeApplication.java
@@ -2,14 +2,16 @@ package com.aibe.team2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-
 @EnableJpaAuditing
-@SpringBootApplication
+@SpringBootApplication(exclude = {
+        SecurityAutoConfiguration.class
+})
 public class AibeApplication {
     public static void main(String[] args) {
         SpringApplication.run(AibeApplication.class, args);
     }
-
 }

--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -1,30 +1,49 @@
 package com.aibe.team2.domain.interview.controller;
 
-import org.springframework.http.MediaType;
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.entity.InterviewStatus;
+import com.aibe.team2.domain.interview.service.InterviewManager;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
+import java.util.concurrent.Executors;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/interviews")
 public class InterviewController {
 
-    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter connect() {
-        // SSE 연결 객체 생성 (유효시간 30분)
-        SseEmitter emitter = new SseEmitter(30 * 60 * 1000L);
+    private final InterviewManager interviewManager;
 
-        try {
-            // 연결 직후 데이터를 보내야 연결 유지가 됨
-            emitter.send(SseEmitter.event()
-                    .name("connect")
-                    .data("실시간 면접 세션에 연결되었습니다."));
-        } catch (IOException e) {
-            emitter.completeWithError(e);
-        }
+    @GetMapping(value = "/start-test", produces = "text/event-stream;charset=UTF-8")
+    public SseEmitter startInterviewWithDb() {
+        // 면접 세션 생성
+        InterviewSession session = interviewManager.startInterview("TEXT");
+
+        SseEmitter emitter = new SseEmitter(120 * 1000L);
+        String fullSentence = "반갑습니다. 면접 세션(" + session.getId() + ")이 생성되었습니다.";
+        String[] characters = fullSentence.split("");
+
+        Executors.newSingleThreadExecutor().execute(() -> {
+            try {
+                // 상태 전이: READY
+                interviewManager.advanceStatus(session.getId(), InterviewStatus.READY);
+
+                for (String character : characters) {
+                    emitter.send(SseEmitter.event().data(character));
+                    Thread.sleep(100);
+                }
+
+                // 상태 전이: ANSWERING
+                interviewManager.advanceStatus(session.getId(), InterviewStatus.ANSWERING);
+                emitter.complete();
+            } catch (Exception e) {
+                emitter.completeWithError(e);
+            }
+        });
 
         return emitter;
     }

--- a/src/main/java/com/aibe/team2/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/com/aibe/team2/domain/interview/entity/InterviewSession.java
@@ -1,0 +1,32 @@
+package com.aibe.team2.domain.interview.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewSession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private InterviewStatus status;
+
+    private String type; // TEXT 또는 VOICE
+
+    @Builder
+    public InterviewSession(String type) {
+        this.status = InterviewStatus.CREATED;
+        this.type = type;
+    }
+
+    public void updateStatus(InterviewStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/interview/entity/InterviewStatus.java
+++ b/src/main/java/com/aibe/team2/domain/interview/entity/InterviewStatus.java
@@ -1,0 +1,8 @@
+package com.aibe.team2.domain.interview.entity;
+
+public enum InterviewStatus {
+    CREATED,      // 세션 생성됨
+    READY,        // 질문 준비 완료
+    ANSWERING,    // 답변 중
+    COMPLETED     // 면접 종료
+}

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewRepository.java
@@ -1,0 +1,7 @@
+package com.aibe.team2.domain.interview.repository;
+
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewRepository extends JpaRepository<InterviewSession, Long> {
+}

--- a/src/main/java/com/aibe/team2/domain/interview/service/InterviewManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/InterviewManager.java
@@ -1,0 +1,30 @@
+package com.aibe.team2.domain.interview.service;
+
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.entity.InterviewStatus;
+import com.aibe.team2.domain.interview.repository.InterviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewManager {
+
+    private final InterviewRepository interviewRepository;
+
+    @Transactional
+    public InterviewSession startInterview(String type) {
+        InterviewSession session = InterviewSession.builder()
+                .type(type)
+                .build();
+        return interviewRepository.save(session);
+    }
+
+    @Transactional
+    public void advanceStatus(Long sessionId, InterviewStatus nextStatus) {
+        InterviewSession session = interviewRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+        session.updateStatus(nextStatus);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,28 +1,65 @@
 spring:
   application:
     name: aibe-team2-api
-
   profiles:
     active: dev
-
-  jpa:
-    open-in-view: false
-    hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate:
-        format_sql: true
-
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
 
   servlet:
     multipart:
       max-file-size: 10MB
       max-request-size: 20MB
 
+
+---
+# H2
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+
+---
+# MySQL
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: jdbc:mysql://localhost:3306/synctalk?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${MYSQL_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+
+---
 server:
   port: 8080
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
 
 logging:
   level:


### PR DESCRIPTION
## 관련 이슈
- closed: #14

## 작업 내용
- 면접 세션 상태 관리(FSM) 구현: InterviewSession 엔티티와 InterviewStatus (CREATED, READY, ANSWERING)를 통해 면접의 생명주기를 데이터베이스화
- InterviewManager 서비스 구축: 세션 생성 및 상태 전이 로직을 @Transactional 기반으로 안전하게 구현
- SSE 실시간 스트리밍 컨트롤러: 비동기 SseEmitter를 활용하여 면접 질문을 한 글자씩 실시간으로 송출하는 API를 구현
- 로컬 환경 검증: H2 콘솔을 통해 상태 값이 ANSWERING으로 정상 변경되는 것을 확인
<br/>

## 변경 사항 및 주의 사항
- application.yml 구조 변경: dev(H2)와 prod(MySQL 8.0) 프로파일을 분리
인코딩 설정 최적화: SSE 스트리밍 시 한글 깨짐 방지를 위해 server.servlet.encoding 설정을 - 최상단 공통 영역으로 이동 및 구조를 보정
- 협업 시 참고: 로컬 개발 시에는 active: dev로 유지해 주시고, MySQL 연동 테스트 시에만 prod로 전환 바람

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #
