### PR TITLE
[FEAT] 마이페이지 프로필 조회 및 수정 기능 기본 구현

### DIFF
--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MemberController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MemberController.java
@@ -1,0 +1,72 @@
+package com.aibe.team2.domain.mypage.controller;
+
+import com.aibe.team2.domain.mypage.dto.response.MemberResponseDto;
+import com.aibe.team2.domain.mypage.dto.response.MemberUpdateResponseDto;
+import com.aibe.team2.domain.mypage.dto.request.PasswordChangeRequestDto;
+import com.aibe.team2.domain.mypage.dto.request.ProfileUpdateDto;
+import com.aibe.team2.domain.mypage.dto.response.PasswordChangeResponse;
+import com.aibe.team2.domain.mypage.service.MemberService;
+import com.aibe.team2.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // TODO : 보안 연동
+    // Spring Security 생성 전 PE와 통신 테스트를 위해 임시로 ID를 1L로 고정
+    // 이후 로그인 파트가 완성되면 @AuthenticationPrincipal 어노테이션으로 실제 유저 ID를 받아오도록 수정 필요
+    private Long getLoginMemberId(){
+        return 1L; // 항상 회원의 정보가 수정되도록 임시 고정
+    }
+
+    // [FR-MYP-05] 프로필 조회
+    @GetMapping("/profile")
+    public ResponseEntity<MemberResponseDto> getProfile(){
+        Long memberId = getLoginMemberId();
+        MemberResponseDto response = memberService.getMemberInfo(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    // [FR-MYP-01] 프로필 수정
+    @PatchMapping("/profile")
+    public ResponseEntity<ApiResponse<MemberUpdateResponseDto>> updateProfile( // 제네릭 타입 변경
+                                                                               @Valid @RequestBody ProfileUpdateDto dto
+    ){
+        Long memberId = getLoginMemberId();
+
+        // 반환받는 변수의 타입도 신규 DTO로 변경
+        MemberUpdateResponseDto response = memberService.updateProfile(memberId, dto);
+
+        ApiResponse<MemberUpdateResponseDto> apiResponse = ApiResponse.<MemberUpdateResponseDto>builder()
+                .success(true)
+                .code("OK")
+                .message("프로필 수정이 완료되었습니다.")
+                .data(response)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    // [FR-MYP-02] 비밀번호 변경
+    @PatchMapping("/password")
+    public ResponseEntity<PasswordChangeResponse> changePassword(
+            @Valid @RequestBody PasswordChangeRequestDto dto
+    ){
+        Long memberId = getLoginMemberId();
+        memberService.changePassword(memberId, dto);
+
+        PasswordChangeResponse response = new PasswordChangeResponse(
+                200,
+                "비밀번호가 성공적으로 변경되었습니다."
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/request/JobPreferenceUpdateRequestDto.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/request/JobPreferenceUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.aibe.team2.domain.mypage.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JobPreferenceUpdateRequestDto {
+    private List<String> targetJobRoles;
+
+    private String preferredLocation;
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/request/PasswordChangeRequestDto.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/request/PasswordChangeRequestDto.java
@@ -1,0 +1,24 @@
+package com.aibe.team2.domain.mypage.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordChangeRequestDto {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,16}$",
+            message = "비밀번호는 8~16자 영문, 숫자, 특수문자를 사용하세요."
+    )
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인을 입력해주세요.")
+    private String confirmPassword;
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/request/ProfileUpdateDto.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/request/ProfileUpdateDto.java
@@ -1,0 +1,16 @@
+package com.aibe.team2.domain.mypage.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProfileUpdateDto {
+
+    private String nickname;
+
+    private String profileImageUrl; // 제거 시 null 또는 빈 값 전송
+
+    private JobPreferenceUpdateRequestDto jobPreferences;
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/response/MemberResponseDto.java
@@ -1,0 +1,46 @@
+package com.aibe.team2.domain.mypage.dto.response;
+
+import com.aibe.team2.domain.mypage.entity.Member;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class MemberResponseDto {
+    private final String email;
+    private final String nickname;
+    private final String profileImageUrl;
+
+    private final JobPreferencesDto  jobPreferences;
+
+    public MemberResponseDto(Member member) {
+        this.email = member.getEmail();
+        this.nickname = member.getNickname();
+        this.profileImageUrl = member.getProfileImageUrl();
+
+        this.jobPreferences = new JobPreferencesDto(member);
+    }
+
+    @Getter
+    public static class JobPreferencesDto {
+        private final List<String> targetJobRoles;
+        private final String preferredLocation;
+
+        public JobPreferencesDto(Member member) {
+            this.targetJobRoles = parseJobRoles(member.getDesiredJobRole());
+            this.preferredLocation = member.getPreferredLocation();
+        }
+
+        private List<String> parseJobRoles(String jobRoles){
+            if(jobRoles == null || jobRoles.isBlank()){
+                return List.of();
+            }
+
+            return Arrays.stream(jobRoles.split(","))
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/response/MemberUpdateResponseDto.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/response/MemberUpdateResponseDto.java
@@ -1,0 +1,26 @@
+package com.aibe.team2.domain.mypage.dto.response;
+
+import com.aibe.team2.domain.mypage.entity.Member;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MemberUpdateResponseDto {
+    private final Long userId;
+    private final String email;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final MemberResponseDto.JobPreferencesDto jobPreferences;
+    private final LocalDateTime updatedAt;
+
+    public MemberUpdateResponseDto(Member member) {
+        this.userId = member.getId();
+        this.email = member.getEmail();
+        this.nickname = member.getNickname();
+        this.profileImageUrl = member.getProfileImageUrl();
+
+        this.jobPreferences = new MemberResponseDto.JobPreferencesDto(member);
+        this.updatedAt = member.getUpdatedAt();
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/response/PasswordChangeResponse.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/response/PasswordChangeResponse.java
@@ -1,0 +1,11 @@
+package com.aibe.team2.domain.mypage.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordChangeResponse {
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
@@ -1,0 +1,98 @@
+package com.aibe.team2.domain.mypage.entity;
+
+import com.aibe.team2.domain.mypage.entity.enums.Role;
+import com.aibe.team2.domain.mypage.entity.enums.Provider;
+import com.aibe.team2.domain.mypage.entity.enums.SubscriptionPlan;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "auth_provider")
+    private Provider provider;
+
+    @Column(name = "desired_job", length = 100)
+    private String desiredJobRole;
+
+    @Column(name = "preferred_location", length = 100)
+    private String preferredLocation;
+
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "subscription_plan")
+    private SubscriptionPlan subscriptionPlan;
+
+    @Column(name = "credit_balance")
+    private Integer creditBalance;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public Member(
+            String email, String password, String nickname, Role role, Provider provider
+    ){
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.role = role != null ? role : Role.MEMBER;
+        this.provider = provider;
+
+        this.subscriptionPlan = SubscriptionPlan.FREE;
+        this.creditBalance = 0;
+
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateProfile(String nickname, String profileImageUrl) {
+        if(nickname != null && !nickname.isEmpty())
+            this.nickname = nickname;
+        if(profileImageUrl != null && !profileImageUrl.isEmpty())
+            this.profileImageUrl = profileImageUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updatePassword(String encodedNewPassword) {
+        this.password = encodedNewPassword;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateJobPreferences(String desiredJobRole, String preferredLocation) {
+        this.desiredJobRole = desiredJobRole;
+        this.preferredLocation = preferredLocation;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/entity/enums/Provider.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/enums/Provider.java
@@ -1,0 +1,7 @@
+package com.aibe.team2.domain.mypage.entity.enums;
+
+public enum Provider {
+    LOCAL,
+    GOOGLE,
+    KAKAO
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/entity/enums/Role.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/enums/Role.java
@@ -1,0 +1,6 @@
+package com.aibe.team2.domain.mypage.entity.enums;
+
+public enum Role {
+    MEMBER,
+    ADMIN
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/entity/enums/SubscriptionPlan.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/enums/SubscriptionPlan.java
@@ -1,0 +1,15 @@
+package com.aibe.team2.domain.mypage.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubscriptionPlan {
+
+    FREE("무료 플랜"),
+    PRO("프로 플랜"),
+    ENTERPRISE("엔터프라이즈 플랜");
+
+    private final String description;
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepository.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.aibe.team2.domain.mypage.repository;
 
 import com.aibe.team2.domain.mypage.entity.Member;
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.custom.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,4 +16,10 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
 
     // 2. 닉네임으로 회원 찾기(닉네임 중복 검사 시 사용)
     Optional<Member> findByNickname(String nickname);
+
+    // 3. ID로 멤버 찾기(없으면 예외 발생)
+    default Member getByIdThrow(Long memberId) {
+        return findById(memberId)
+                .orElseThrow(()-> new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepository.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package com.aibe.team2.domain.mypage.repository;
+
+import com.aibe.team2.domain.mypage.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member,Long> {
+
+    // 1. 이메일로 회원 찾기
+    Optional<Member> findByEmail(String email);
+
+    // 2. 닉네임으로 회원 찾기(닉네임 중복 검사 시 사용)
+    Optional<Member> findByNickname(String nickname);
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
@@ -25,22 +25,16 @@ public class MemberService {
     // TODO : Security Config에 PasswordEncoder Bean 등록 시 주석 풀기
     // private final PasswordEncoder passwordEncoder;
 
-    // [공통] ID로 멤버 찾기
-    private Member findMemberById(Long memberId){
-        return memberRepository.findById(memberId)
-                .orElseThrow(()->new NotFoundException(ErrorCode.USER_NOT_FOUND));
-    }
-
     // 1. 마이페이지 정보 조회
     public MemberResponseDto getMemberInfo(Long memberId){
-        Member member = findMemberById(memberId);
+        Member member = memberRepository.getByIdThrow(memberId);
         return new MemberResponseDto(member);
     }
 
     // 2. 프로필 수정 (통합 메서드)
     @Transactional
     public MemberUpdateResponseDto updateProfile (Long memberId, ProfileUpdateDto dto) {
-        Member member = findMemberById(memberId);
+        Member member = memberRepository.getByIdThrow(memberId);
 
         // 2-1. 프로필 기본 정보 업데이트
         member.updateProfile(dto.getNickname(), dto.getProfileImageUrl());
@@ -58,7 +52,7 @@ public class MemberService {
     // 3. 비밀번호 변경
     @Transactional
     public void changePassword(Long memberId, PasswordChangeRequestDto dto){
-        Member member = findMemberById(memberId);
+        Member member = memberRepository.getByIdThrow(memberId);
 
         // 3-1. 현재 비밀번호 검증
         // TODO : [삭제] 임시 평문 비교
@@ -86,7 +80,7 @@ public class MemberService {
     // 4. 취업 선호 설정 수정
     @Transactional
     public void updateJobPreferences(Long memberId, JobPreferenceUpdateRequestDto dto){
-        Member member = findMemberById(memberId);
+        Member member = memberRepository.getByIdThrow(memberId);
 
         List<String> rolesList = dto.getTargetJobRoles();
         String joinedRoles = (rolesList != null && !rolesList.isEmpty())

--- a/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
@@ -1,0 +1,99 @@
+package com.aibe.team2.domain.mypage.service;
+
+import com.aibe.team2.domain.mypage.dto.request.JobPreferenceUpdateRequestDto;
+import com.aibe.team2.domain.mypage.dto.request.PasswordChangeRequestDto;
+import com.aibe.team2.domain.mypage.dto.request.ProfileUpdateDto;
+import com.aibe.team2.domain.mypage.dto.response.MemberResponseDto;
+import com.aibe.team2.domain.mypage.dto.response.MemberUpdateResponseDto;
+import com.aibe.team2.domain.mypage.entity.Member;
+import com.aibe.team2.domain.mypage.repository.MemberRepository;
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.custom.BadRequestException;
+import com.aibe.team2.global.exception.custom.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    // TODO : Security Config에 PasswordEncoder Bean 등록 시 주석 풀기
+    // private final PasswordEncoder passwordEncoder;
+
+    // [공통] ID로 멤버 찾기
+    private Member findMemberById(Long memberId){
+        return memberRepository.findById(memberId)
+                .orElseThrow(()->new NotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // 1. 마이페이지 정보 조회
+    public MemberResponseDto getMemberInfo(Long memberId){
+        Member member = findMemberById(memberId);
+        return new MemberResponseDto(member);
+    }
+
+    // 2. 프로필 수정 (통합 메서드)
+    @Transactional
+    public MemberUpdateResponseDto updateProfile (Long memberId, ProfileUpdateDto dto) {
+        Member member = findMemberById(memberId);
+
+        // 2-1. 프로필 기본 정보 업데이트
+        member.updateProfile(dto.getNickname(), dto.getProfileImageUrl());
+
+        // 2-2. 취업 선호 설정이 포함되어 있다면 기존 로직(4번) 재사용
+        if (dto.getJobPreferences() != null) {
+            // 내부 메서드를 호출하여 로직 중복 방지 (DRY 원칙)
+            this.updateJobPreferences(memberId, dto.getJobPreferences());
+        }
+
+        // 2-3. 수정이 완료된 엔티티를 Response DTO로 변환하여 반환
+        return new MemberUpdateResponseDto(member);
+    }
+
+    // 3. 비밀번호 변경
+    @Transactional
+    public void changePassword(Long memberId, PasswordChangeRequestDto dto){
+        Member member = findMemberById(memberId);
+
+        // 3-1. 현재 비밀번호 검증
+        // TODO : [삭제] 임시 평문 비교
+        if(!dto.getCurrentPassword().equals(member.getPassword())){
+            throw new BadRequestException(ErrorCode.COMMON_400);
+        }
+        // TODO : [주석 해제] 최종 암호화 비교
+        // if (!passwordEncoder.matches(dto.getCurrentPassword(), member.getPassword())) {
+        //             throw new BadRequestException(ErrorCode.COMMON_400);
+        //         }
+
+        // 3-2. 새 비밀번호 일치 검증
+        if(!dto.getNewPassword().equals(dto.getConfirmPassword())){
+            throw new BadRequestException(ErrorCode.COMMON_400);
+        }
+
+        // 3-3. 비밀번호 업데이트
+        // TODO : [삭제] 임시 평문 저장
+        member.updatePassword(dto.getNewPassword());
+        // TODO : [주석 해제] 최종 암호화 저장
+        // String encodedNewPassword = passwordEncoder.encode(dto.getNewPassword());
+        //         member.updatePassword(encodedNewPassword);
+    }
+
+    // 4. 취업 선호 설정 수정
+    @Transactional
+    public void updateJobPreferences(Long memberId, JobPreferenceUpdateRequestDto dto){
+        Member member = findMemberById(memberId);
+
+        List<String> rolesList = dto.getTargetJobRoles();
+        String joinedRoles = (rolesList != null && !rolesList.isEmpty())
+                ? String.join(",", rolesList)
+                : null;
+
+        member.updateJobPreferences(joinedRoles, dto.getPreferredLocation());
+    }
+
+}

--- a/src/main/java/com/aibe/team2/global/redis/RedisConfig.java
+++ b/src/main/java/com/aibe/team2/global/redis/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.aibe.team2.global.redis;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -10,10 +11,16 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
     // 1. Redis 연결을 위한 ConnectionFactory 생성
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory("localhost", 6379);
+        return new LettuceConnectionFactory(host, port);
     }
 
     // 2. 데이터 제어를 위한 RedisTemplate 생성


### PR DESCRIPTION
## 관련 이슈
- closed: #22 

## 작업 내용
- 도메인 엔티티 및 Enum 설계 : Member 엔티티 생성 및 관련 상태값 Enum 클래스 정의
- DTO 생성 : 프로필 조회 및 수정, 비밀번호 변경, 직무 성향 업데이트를 위한 DTO 세팅
- 레포지토리 및 서비스 로직 구축 : MemberRepository 생성 및 MemberService 내 정보 업데이트 비즈니스 로직 작성
- API 컨트롤러 생성 : MemberController를 통해 클라이언트 요청을 받을 기본 엔드 포인트 설계
<br/>

## 변경 사항 및 주의 사항
- 조회 성능 및 로직: 현재는 Spring Data JPA의 기본 메서드를 활용하여 구현했습니다. 추후 성능 최적화가 필요해지면 QueryDSL을 도입하는 방향으로 고도화할 예정입니다.
- 이미지 URL 처리: S3 인프라 연동 전이므로, 우선은 클라이언트에서 임의의 문자열(String) 형태의 이미지 URL을 넘겨준다고 가정하고 DB에 업데이트하도록 구현했습니다. S3 연동 완료 후 파일 업로드 로직으로 변경이 필요합니다.
- 테스트 환경: 아직 Swagger 연동 작업 전이므로, 해당 API 동작을 확인하려면 로컬 환경에서 Postman을 활용한 테스트를 권장합니다.
<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
