### PR TITLE
[CHORE] 백엔드 QueryDSL 공통 환경 세팅 및 템플릿 문서 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ application-dev.yml
 
 # localstack local cache
 localstack/
+
+### QueryDSL ###
+# Gradle 기본 빌드 디렉토리 하위 generated 폴더 제외
+/build/generated
+
+# IDE의 자체 빌더가 src/main/generated에 생성할 경우 대비
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // Swagger UI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
@@ -56,6 +62,17 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+}
+
+// Q-Class
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(querydslDir)
+}
+
+clean{
+    delete file(querydslDir)
 }
 
 tasks.named('test') {

--- a/docs/QueryDSL Convention.md
+++ b/docs/QueryDSL Convention.md
@@ -5,7 +5,11 @@
 
 ---
 
-## 1. Custom 인터페이스 (명세서)
+## 1. QueryDSL 도입 배경
+- 자바 코드 기반으로 쿼리를 작성해 컴파일 타임에 문법 오류를 사전에 차단하는 타입 안정성 확보 목적
+- 서비스 전반에서 발생하는 복잡한 테이블 조인과 동적 쿼리를 직관적인 객체 지향 코드로 해결해 **코드 재사용성**과 **유지보수성 극대화**
+
+## 2. Custom 인터페이스 (명세서)
 - **파일 이름:** `[Domain]RepositoryCustom.java`
 - **역할:** QueryDSL로 구현할 동적 쿼리 메서드의 이름과 반환 타입을 선언합니다.
 
@@ -18,7 +22,7 @@ public interface [Domain]RepositoryCustom {
 }
 ```
 
-## 2. Impl 구현체 (실제 쿼리 작성)
+## 3. Impl 구현체 (실제 쿼리 작성)
 - **파일 이름:** `[Domain]RepositoryImpl.java`
 - **역할:** Custom 인터페이스를 상속받아 `JPAQueryFactory`를 이용해 실제 QueryDSL 코드를 작성합니다.
 - ⚠️ **주의:** 파일 이름은 반드시 `인터페이스명 + Impl` 형태를 지켜야 합니다.
@@ -62,7 +66,7 @@ public class [Domain]RepositoryImpl implements [Domain]RepositoryCustom {
 }
 ```
 
-## 3. 기본 Repository (통합 인터페이스)
+## 4. 기본 Repository (통합 인터페이스)
 - **파일 이름:** `[Domain]Repository.java`
 - **역할:** `JpaRepository`와 우리가 만든 `Custom` 인터페이스를 다중 상속받아 최종적으로 서비스(Service) 계층에서 호출하는 인터페이스입니다.
 

--- a/docs/QueryDSL Convention.md
+++ b/docs/QueryDSL Convention.md
@@ -1,0 +1,78 @@
+# 📌 QueryDSL 커스텀 리포지토리(Custom Repository) 사용 가이드
+
+복잡한 동적 쿼리를 작성할 때 사용하는 QueryDSL 보일러플레이트 템플릿입니다. <br/>
+아래 코드를 복사하여 `[Domain]` 부분을 본인이 담당하는 엔티티(Entity) 이름으로 변경하여 사용하세요.
+
+---
+
+## 1. Custom 인터페이스 (명세서)
+- **파일 이름:** `[Domain]RepositoryCustom.java`
+- **역할:** QueryDSL로 구현할 동적 쿼리 메서드의 이름과 반환 타입을 선언합니다.
+
+```java
+import java.util.List;
+
+public interface [Domain]RepositoryCustom {
+    // TODO: QueryDSL로 작성할 동적 쿼리 메서드 선언
+    // 예시: List<[Domain]> search[Domain]s(String keyword);
+}
+```
+
+## 2. Impl 구현체 (실제 쿼리 작성)
+- **파일 이름:** `[Domain]RepositoryImpl.java`
+- **역할:** Custom 인터페이스를 상속받아 `JPAQueryFactory`를 이용해 실제 QueryDSL 코드를 작성합니다.
+- ⚠️ **주의:** 파일 이름은 반드시 `인터페이스명 + Impl` 형태를 지켜야 합니다.
+
+```java
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+// TODO: 본인 도메인의 Q-Class 정적 임포트 (필수)
+// import static com.aibe.team2.global.domain.Q[Domain].[domain];
+
+@Repository
+@RequiredArgsConstructor
+public class [Domain]RepositoryImpl implements [Domain]RepositoryCustom {
+
+    // 공통 환경 설정에서 등록한 빈(Bean)을 주입받아 사용합니다.
+    private final JPAQueryFactory queryFactory;
+
+    // TODO: Custom 인터페이스에 선언한 메서드 구현
+    /* 예시 코드
+    @Override
+    public List<[Domain]> search[Domain]s(String keyword) {
+        return queryFactory
+                .selectFrom([domain])
+                .where(
+                        keywordContains(keyword) // 동적 쿼리 조건
+                )
+                .fetch();
+    }
+
+    // 동적 쿼리를 위한 BooleanExpression 메서드 분리 (null 반환 시 조건 무시됨)
+    private BooleanExpression keywordContains(String keyword) {
+        return StringUtils.hasText(keyword) ? [domain].title.contains(keyword) : null;
+    }
+    */
+}
+```
+
+## 3. 기본 Repository (통합 인터페이스)
+- **파일 이름:** `[Domain]Repository.java`
+- **역할:** `JpaRepository`와 우리가 만든 `Custom` 인터페이스를 다중 상속받아 최종적으로 서비스(Service) 계층에서 호출하는 인터페이스입니다.
+
+```java
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface [Domain]Repository extends JpaRepository<[Domain], Long>, [Domain]RepositoryCustom {
+    // Spring Data JPA 기본 메서드(save, findById 등)와
+    // QueryDSL로 구현한 Custom 메서드를 모두 여기서 호출 가능합니다.
+}
+```

--- a/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepository.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member,Long> {
+public interface MemberRepository extends JpaRepository<Member,Long>, MemberRepositoryCustom {
 
     // 1. 이메일로 회원 찾기
     Optional<Member> findByEmail(String email);

--- a/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.aibe.team2.domain.mypage.repository;
+
+import com.aibe.team2.domain.mypage.entity.Member;
+
+import java.util.Optional;
+
+public interface MemberRepositoryCustom {
+    // 테스트용 : QueryDSL을 사용해 프로필 ID로 회원 찾기
+    Optional<Member> findProfileByIdWithQueryDSL(Long memberId);
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/repository/MemberRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.aibe.team2.domain.mypage.repository;
+
+import com.aibe.team2.domain.mypage.entity.Member;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+import static com.aibe.team2.domain.mypage.entity.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Member> findProfileByIdWithQueryDSL(Long memberId) {
+        Member findMember = queryFactory
+                .selectFrom(member)
+                .where(member.id.eq(memberId)) // 조건 : ID가 일치하는 직원
+                .fetchOne(); // 단건 조회
+
+        return Optional.ofNullable(findMember);
+    }
+}

--- a/src/main/java/com/aibe/team2/global/config/QuerydslConfig.java
+++ b/src/main/java/com/aibe/team2/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.aibe.team2.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/com/aibe/team2/domain/mypage/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/aibe/team2/domain/mypage/repository/MemberRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.aibe.team2.domain.mypage.repository;
+
+import com.aibe.team2.domain.mypage.entity.Member;
+import com.aibe.team2.domain.mypage.entity.enums.Provider;
+import com.aibe.team2.domain.mypage.entity.enums.Role;
+import com.aibe.team2.global.config.QuerydslConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+// 🎯 검증을 위한 AssertJ 라이브러리의 올바른 임포트 경로입니다.
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QuerydslConfig.class)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("QueryDSL을 이용한 프로필 조회 테스트가 정상 작동한다.")
+    void findProfileByIdWithQueryDSL_Test() {
+        // Given: 더미 멤버 데이터 저장 (기존에 작성해두신 생성자 활용)
+        Member newMember = new Member(
+                "test@example.com", // email
+                "password123",      // password
+                "개발왕",            // nickname
+                Role.MEMBER,        // role
+                Provider.LOCAL      // provider (원하시는 Provider Enum으로 변경 가능)
+        );
+        Member savedMember = memberRepository.save(newMember);
+
+        // When: 작성한 QueryDSL 메서드 호출
+        Optional<Member> foundMember = memberRepository.findProfileByIdWithQueryDSL(savedMember.getId());
+
+        // Then: 저장한 데이터와 QueryDSL로 찾은 데이터가 일치하는지 확인
+        assertThat(foundMember).isPresent(); // 데이터가 존재하는지 확인
+        assertThat(foundMember.get().getNickname()).isEqualTo("개발왕"); // 닉네임 일치 확인
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closed: #34, closed: #35

## 작업 내용
- `build.gradle`에 QueryDSL 관련 의존성 및 Q-Class 생성 스크립트 추가
- `.gitignore` 파일에 Q-Class 생성 경로)를 추가하여 깃(Git) 병합 시 충돌 원천 차단
- `global/config` 패키지에 `QuerydslConfig` 클래스를 생성하여 `JPAQueryFactory` 스프링 빈 등록 완료
- 팀원 협업을 위한 QueryDSL 커스텀 리포지토리 보일러플레이트 가이드 문서 작성 (`docs/QueryDSL Convention.md`)
- `Member` 샘플 도메인에 커스텀 리포지토리 패턴(Custom 인터페이스 및 Impl 구현체) 뼈대 구축
- `@DataJpaTest`와 H2 인메모리 DB를 활용하여 Q-Class 정상 생성 및 `select` 동적 쿼리 동작 로컬 검증 완료
<br/>

## 변경 사항 및 주의 사항
- 🚨 **[필수] 로컬 환경 동기화:** 본 PR을 로컬 브랜치로 `pull` 받으신 후, IDE 우측의 **Gradle 탭에서 `clean` 실행 후 `compileJava`를 반드시 한 번 실행**하여 본인 PC에도 Q-Class를 생성해 주세요.
- **문서 참고:** 통계, 마이페이지 등 복잡한 동적 쿼리 작성이 필요할 때는 `docs/QueryDSL Convention.md` 파일의 템플릿을 복사하여 엔티티 이름만 변경해 사용하시면 됩니다.
- **구현체 네이밍 강제 규칙:** 커스텀 리포지토리 구현체 클래스의 이름은 반드시 `인터페이스명 + Impl` 형태를 지켜야만 Spring Data JPA가 정상적으로 인식합니다. (예: `MemberRepositoryImpl`)

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

