### PR TITLE
[FEAT] 텍스트 및 음성 면접 기능 구현

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
@@ -4,18 +4,23 @@ import com.aibe.team2.domain.interview.dto.VoiceSessionResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
 import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
 public class ConversationManager {
+
     private final OpenAiService openAiService;
     private final RetellService retellService;
 
+    // [Real Mode] OpenAI 스트리밍 연결
     public void startTextStreaming(String answer, SseEmitter emitter) {
         openAiService.streamQuestion(answer).subscribe(
                 data -> {
                     try {
+                        // OpenAI의 응답 데이터(JSON)를 그대로 클라이언트에 전송
+                        // (프론트엔드에서 파싱 필요, 또는 여기서 파싱해서 content만 보낼 수도 있음)
                         emitter.send(SseEmitter.event().name("message").data(data));
                     } catch (IOException e) {
                         emitter.completeWithError(e);
@@ -26,6 +31,7 @@ public class ConversationManager {
         );
     }
 
+    // [Real Mode] Retell AI 세션 생성
     public VoiceSessionResponse startVoiceInterview(Long sessionId) {
         return retellService.createVoiceCall(sessionId);
     }

--- a/src/main/java/com/aibe/team2/domain/interview/service/OpenAiService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/OpenAiService.java
@@ -4,14 +4,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
+
 import java.util.List;
 import java.util.Map;
 
 @Service
 public class OpenAiService {
+
     private final WebClient webClient;
 
-    @Value("${openai.api.key}") // application.yml의 환경변수 참조
+    @Value("${openai.api.key}")
     private String apiKey;
 
     public OpenAiService(WebClient.Builder webClientBuilder) {
@@ -23,14 +25,14 @@ public class OpenAiService {
                 .uri("/chat/completions")
                 .header("Authorization", "Bearer " + apiKey)
                 .bodyValue(Map.of(
-                        "model", "gpt-4o",
+                        "model", "gpt-4o", // 또는 gpt-3.5-turbo
                         "messages", List.of(
-                                Map.of("role", "system", "content", "당신은 전문 면접관입니다. 자소서 내용을 바탕으로 날카로운 꼬리 질문을 한 문장으로 하세요."),
+                                Map.of("role", "system", "content", "당신은 면접관입니다. 지원자의 답변을 듣고 꼬리 질문을 한 문장으로 하세요."),
                                 Map.of("role", "user", "content", userMessage)
                         ),
-                        "stream", true
+                        "stream", true // 핵심: 스트리밍 활성화
                 ))
                 .retrieve()
-                .bodyToFlux(String.class);
+                .bodyToFlux(String.class); // 응답이 올 때마다 흘려보냄
     }
 }

--- a/src/main/java/com/aibe/team2/domain/interview/service/RetellService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/RetellService.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+
 import java.util.Map;
 
 @Service
@@ -19,6 +20,7 @@ public class RetellService {
     @Value("${retell.agent.id}")
     private String agentId;
 
+    // Retell 서버에 '전화 걸기'를 요청하고 토큰을 받아옵니다.
     public VoiceSessionResponse createVoiceCall(Long sessionId) {
         RestTemplate restTemplate = new RestTemplate();
         String url = "https://api.retellai.com/v2/create-web-call";
@@ -33,6 +35,8 @@ public class RetellService {
         );
 
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+
+        // 실제 API 호출
         ResponseEntity<Map> response = restTemplate.postForEntity(url, entity, Map.class);
 
         String accessToken = (String) response.getBody().get("access_token");

--- a/src/main/java/com/aibe/team2/global/config/SecurityConfig.java
+++ b/src/main/java/com/aibe/team2/global/config/SecurityConfig.java
@@ -17,6 +17,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/",
+                                "/index.html",
+                                "/api/interviews/**",
                                 "/actuator/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"

--- a/src/main/java/com/aibe/team2/global/config/WebConfig.java
+++ b/src/main/java/com/aibe/team2/global/config/WebConfig.java
@@ -1,0 +1,15 @@
+package com.aibe.team2.global.config; // 패키지명은 프로젝트 구조에 맞게 조정
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 주소 허용
+                .allowedOrigins("*") // 모든 출처 허용 (개발용)
+                .allowedMethods("GET", "POST", "PUT", "DELETE");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,8 @@
 spring:
   application:
     name: aibe-team2-api
-
+  profiles:
+    active: dev
   servlet:
     multipart:
       max-file-size: 10MB

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AIBE Team2 - AI 하이브리드 실전 면접</title>
+    <style>
+        body { font-family: 'Pretendard', sans-serif; text-align: center; padding: 20px; background-color: #f8f9fa; }
+        .container { max-width: 600px; margin: 0 auto; padding: 30px; background: white; border-radius: 12px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+        h1 { color: #333; }
+
+        /* 모드 선택 스위치 */
+        .mode-switch { margin: 20px 0; display: flex; justify-content: center; gap: 10px; }
+        .mode-btn { padding: 10px 20px; border: 1px solid #007bff; background: white; color: #007bff; border-radius: 20px; cursor: pointer; font-weight: bold; transition: 0.2s; }
+        .mode-btn.active { background: #007bff; color: white; }
+
+        /* 공통 버튼 */
+        .action-btn { padding: 12px 24px; font-size: 16px; cursor: pointer; background-color: #28a745; color: white; border: none; border-radius: 8px; font-weight: bold; }
+        .action-btn:disabled { background-color: #ccc; cursor: not-allowed; }
+
+        /* 음성 면접 영역 */
+        #voiceSection { display: none; }
+        .visualizer { height: 50px; background-color: #f0f0f0; margin-top: 20px; border-radius: 8px; display: flex; align-items: center; justify-content: center; font-weight: bold; color: #555; }
+
+        /* 텍스트 면접 영역 */
+        #textSection { display: block; }
+        .chat-box { height: 300px; border: 1px solid #ddd; border-radius: 8px; padding: 15px; overflow-y: auto; background: #fafafa; margin-bottom: 15px; display: flex; flex-direction: column; gap: 10px; }
+        .msg { max-width: 80%; padding: 10px 15px; border-radius: 15px; line-height: 1.4; text-align: left; word-break: break-word; }
+        .msg.user { align-self: flex-end; background-color: #007bff; color: white; border-bottom-right-radius: 2px; }
+        .msg.ai { align-self: flex-start; background-color: #e9ecef; color: #333; border-bottom-left-radius: 2px; }
+        .input-group { display: flex; gap: 10px; }
+        .input-group input { flex: 1; padding: 10px; border: 1px solid #ddd; border-radius: 8px; outline: none; }
+    </style>
+</head>
+<body>
+
+<div class="container">
+    <h1>🚀 AI 하이브리드 면접</h1>
+    <p>서버 상태: <span id="server-check" style="font-weight:bold; color:green;">확인 중...</span></p>
+
+    <div class="mode-switch">
+        <button class="mode-btn active" id="btnTextMode">💬 텍스트 면접</button>
+        <button class="mode-btn" id="btnVoiceMode">🎙️ 음성 면접</button>
+    </div>
+
+    <div id="textSection">
+        <div class="chat-box" id="chatBox">
+            <div class="msg ai">안녕하세요. 자기소개 부탁드립니다. (텍스트로 답변을 입력하세요)</div>
+        </div>
+        <div class="input-group">
+            <input type="text" id="answerInput" placeholder="답변을 입력하세요..." autocomplete="off">
+            <button class="action-btn" id="sendTextBtn">전송</button>
+        </div>
+    </div>
+
+    <div id="voiceSection">
+        <div id="status" style="margin-bottom: 15px; font-weight: bold; color: #007bff;">음성 면접 준비 완료</div>
+        <button class="action-btn" id="startVoiceBtn">마이크 켜고 시작하기</button>
+        <div class="visualizer" id="visualizer">🔴 통화 연결 전</div>
+    </div>
+</div>
+
+<script type="module">
+    import { RetellWebClient } from 'https://cdn.skypack.dev/retell-client-js-sdk';
+    const retellWebClient = new RetellWebClient();
+
+    // UI 요소
+    const btnTextMode = document.getElementById('btnTextMode');
+    const btnVoiceMode = document.getElementById('btnVoiceMode');
+    const textSection = document.getElementById('textSection');
+    const voiceSection = document.getElementById('voiceSection');
+
+    // 서버 상태 확인
+    fetch('/api/interviews/check')
+        .then(res => res.text())
+        .then(text => document.getElementById('server-check').innerText = "✅ " + text)
+        .catch(() => document.getElementById('server-check').innerText = "❌ 서버 오프라인");
+
+    // ===== 모드 전환 로직 =====
+    btnTextMode.addEventListener('click', () => {
+        btnTextMode.classList.add('active');
+        btnVoiceMode.classList.remove('active');
+        textSection.style.display = 'block';
+        voiceSection.style.display = 'none';
+    });
+
+    btnVoiceMode.addEventListener('click', () => {
+        btnVoiceMode.classList.add('active');
+        btnTextMode.classList.remove('active');
+        textSection.style.display = 'none';
+        voiceSection.style.display = 'block';
+    });
+
+    // ===== 텍스트 면접 로직 (SSE) =====
+    const chatBox = document.getElementById('chatBox');
+    const answerInput = document.getElementById('answerInput');
+    const sendTextBtn = document.getElementById('sendTextBtn');
+
+    sendTextBtn.addEventListener('click', () => {
+        const answer = answerInput.value.trim();
+        if (!answer) return;
+
+        // 1. 사용자 메시지 화면에 추가
+        appendMessage('user', answer);
+        answerInput.value = '';
+        sendTextBtn.disabled = true;
+
+        // 2. AI 메시지 틀(빈 칸) 만들기
+        const aiMsgDiv = appendMessage('ai', '');
+
+        // 3. SSE 연결 (실시간 스트리밍)
+        const sessionId = 1; // 임시 세션 ID
+        const url = `/api/interviews/${sessionId}/text/stream?answer=${encodeURIComponent(answer)}`;
+        const eventSource = new EventSource(url);
+
+        eventSource.addEventListener('message', (event) => {
+            try {
+                // OpenAI의 JSON 응답일 경우 파싱
+                const parsed = JSON.parse(event.data);
+                if (parsed.choices && parsed.choices[0].delta.content) {
+                    aiMsgDiv.innerHTML += parsed.choices[0].delta.content;
+                }
+            } catch (e) {
+                // 시뮬레이션 모드처럼 단순 텍스트일 경우
+                aiMsgDiv.innerHTML += event.data;
+            }
+            chatBox.scrollTop = chatBox.scrollHeight; // 스크롤 맨 아래로 유지
+        });
+
+        eventSource.addEventListener('error', () => {
+            // 스트리밍이 끝나면 연결 종료
+            eventSource.close();
+            sendTextBtn.disabled = false;
+            answerInput.focus();
+        });
+    });
+
+    // 엔터키 전송 지원
+    answerInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') sendTextBtn.click();
+    });
+
+    function appendMessage(sender, text) {
+        const div = document.createElement('div');
+        div.className = `msg ${sender}`;
+        div.innerText = text;
+        chatBox.appendChild(div);
+        chatBox.scrollTop = chatBox.scrollHeight;
+        return div;
+    }
+
+    // ===== 음성 면접 로직 (기존 코드와 동일) =====
+    const startVoiceBtn = document.getElementById('startVoiceBtn');
+    const statusDiv = document.getElementById('status');
+    const visualizer = document.getElementById('visualizer');
+
+    startVoiceBtn.addEventListener('click', async () => {
+        try {
+            startVoiceBtn.disabled = true;
+            statusDiv.innerText = "서버로부터 토큰 요청 중...";
+
+            const response = await fetch('/api/interviews/1/voice/start', { method: 'POST' });
+            if (!response.ok) throw new Error("토큰 발급 실패!");
+
+            const data = await response.json();
+            statusDiv.innerText = "Retell AI 연결 중...";
+
+            await retellWebClient.startCall({ accessToken: data.accessToken });
+        } catch (error) {
+            statusDiv.innerText = "에러: " + error.message;
+            startVoiceBtn.disabled = false;
+        }
+    });
+
+    retellWebClient.on('call_started', () => {
+        statusDiv.innerText = "🗣️ 면접 진행 중!";
+        visualizer.innerText = "🟢 실시간 대화 연결됨";
+        visualizer.style.backgroundColor = "#e8f5e9";
+    });
+
+    retellWebClient.on('call_ended', () => {
+        statusDiv.innerText = "면접 종료";
+        visualizer.innerText = "🔴 연결 종료";
+        visualizer.style.backgroundColor = "#f0f0f0";
+        startVoiceBtn.disabled = false;
+    });
+
+    retellWebClient.on('user_started_speaking', () => {
+        visualizer.innerText = "🎤 듣고 있습니다...";
+        visualizer.style.border = "2px solid #007bff";
+    });
+
+    retellWebClient.on('user_stopped_speaking', () => {
+        visualizer.innerText = "🤖 AI가 생각 중...";
+        visualizer.style.border = "none";
+    });
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
- closed: #25 

## 작업 내용
OpenAI(텍스트)와 Retell AI(음성)를 사용한 인프라 구축
### 1. Backend: AI Interaction Core
- OpenAI Streaming (SSE): WebClient를 활용하여 GPT-4o의 응답을 실시간으로 전달하는 SSE 로직 구현
- Domain Service Architecture: `ConversationManager`를 통한 면접 세션 흐름 중앙 제어 설계
### 2. Frontend: Hybrid Test UI
- localhost:8080/index 에서 테스트 이용 가능
- Mode Switching: 텍스트와 음성 모드 간 자유로운 전환이 가능한 인터페이스 생성
- Real-time Visuals: EventSource를 통한 타이핑 효과 및 Retell Web SDK 연동(마이크 권한 및 음성 연결)
<br/>

## 변경 사항 및 주의 사항
- 개발 편의를 위해 `/api/interviews/**` 경로의 보안을 한시적으로 해제했습니다.

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #25
