### PR TITLE
[FEAT] 통계 리포트용 DTO 구조 설계 및 JSON Converter 구현

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/com/aibe/team2/domain/interview/entity/InterviewSession.java
@@ -5,15 +5,24 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class) // 추가
 public class InterviewSession {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // 추가
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
     @Enumerated(EnumType.STRING)
     private InterviewStatus status;
@@ -21,10 +30,19 @@ public class InterviewSession {
     private String type; // TEXT 또는 VOICE
 
     @Builder
-    public InterviewSession(String type) {
+    public InterviewSession(Long memberId, String type) {
+        this.memberId = memberId;
         this.status = InterviewStatus.CREATED;
         this.type = type;
     }
+
+    // 추가
+    @Column(name = "final_score")
+    private Integer finalScore;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
 
     public void updateStatus(InterviewStatus status) {
         this.status = status;

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewRepository.java
@@ -1,7 +1,14 @@
 package com.aibe.team2.domain.interview.repository;
 
 import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.entity.InterviewStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface InterviewRepository extends JpaRepository<InterviewSession, Long> {
+    // [추가] 완료된 면접 기록을 최신순으로 가져오기 (마이페이지 통계용)
+    List<InterviewSession> findAllByMemberIdAndStatusOrderByCreatedAtDesc(Long memberId, InterviewStatus status);
 }

--- a/src/main/java/com/aibe/team2/domain/resume/dto/ResumeAnalysisResponse.java
+++ b/src/main/java/com/aibe/team2/domain/resume/dto/ResumeAnalysisResponse.java
@@ -5,6 +5,7 @@ import com.aibe.team2.global.common.constant.AnalysisStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 public record ResumeAnalysisResponse(
         Long id,
@@ -12,15 +13,17 @@ public record ResumeAnalysisResponse(
         Long jobPostingId,
         Integer matchScore,
 
-        @Schema(description = "AI가 생성한 소제목 (JSON 형식의 String)", example = "{\"title\": \"...\", \"reason\": \"...\"}")
-        String generatedSubtitle,
+        // String -> Map<String, Object>
+        // JSON 형식의 String -> JSON 객체
+        @Schema(description = "AI가 생성한 소제목 (JSON 객체)", example = "{\"title\": \"...\", \"reason\": \"...\"}")
+        Map<String, Object> generatedSubtitle,
 
-        @Schema(description = "키워드 분석 결과 (JSON 형식의 String)")
-        String keywordAnalysis,
+        @Schema(description = "키워드 분석 결과 (JSON 객체)")
+        Map<String, Object> keywordAnalysis,
 
-        @Schema(description = "문장 교정 데이터 (JSON 형식의 String)")
-        String sentenceCorrection,
-        // 추후 json 형식의 String은 FE에서 json.parse() 할 것.
+        @Schema(description = "문장 교정 데이터 (JSON 객체)")
+        Map<String, Object> sentenceCorrection,
+        // 추후 json 형식의 String은 FE에서 json.parse() 할 것. -> Spring Boot(Jackson)가 자동으로 JSON 변환을 해주므로 FE에서 json.parse() 할 필요없음
 
         String revisedFullContent,
         AnalysisStatus status,
@@ -31,7 +34,8 @@ public record ResumeAnalysisResponse(
         return new ResumeAnalysisResponse(
                 report.getId(),
                 report.getResume().getId(),
-                report.getJobPostingId(),
+                // [수정]
+                report.getJobPostingId().getId(),
                 report.getMatchScore(),
                 report.getGeneratedSubtitle(),
                 report.getKeywordAnalysis(),

--- a/src/main/java/com/aibe/team2/domain/resume/entity/ResumeAnalysisReport.java
+++ b/src/main/java/com/aibe/team2/domain/resume/entity/ResumeAnalysisReport.java
@@ -1,6 +1,8 @@
 package com.aibe.team2.domain.resume.entity;
 
+import com.aibe.team2.domain.jobposting.entity.JobPosting;
 import com.aibe.team2.global.common.constant.AnalysisStatus;
+import com.aibe.team2.global.converter.JsonAttributeConverter;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,6 +13,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Table(
@@ -37,22 +40,30 @@ public class ResumeAnalysisReport {
     private Resume resume;
 
     // FK (job_posting.id), NOT NULL
-    @Column(name = "job_posting_id", nullable = false)
-    private Long jobPostingId;
+    // ⭐ 객체 참조(@ManyToOne)로 변경
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "job_posting_id", nullable = false)
+    private JobPosting jobPostingId;
 
     @Column(name = "match_score")
     private Integer matchScore;
 
     // JSON 타입 (MySQL 등에서 JSON 컬럼 사용 시 columnDefinition 명시 권장)
+    // ⭐ Convert 어노테이션 추가 및 Map<String, Object> 변환
+    @Convert(converter = JsonAttributeConverter.class)
     @Column(name = "keyword_analysis", columnDefinition = "json")
-    private String keywordAnalysis;
+    private Map<String, Object> keywordAnalysis;
 
+    // ⭐ Convert 어노테이션 추가 및 Map<String, Object> 변환
+    @Convert(converter = JsonAttributeConverter.class)
     @Column(name = "sentence_correction", columnDefinition = "json")
-    private String sentenceCorrection;
+    private Map<String, Object> sentenceCorrection;
 
     // New! 이미지 반영: JSON 타입
+    // ⭐ Convert 어노테이션 추가 및 Map<String, Object> 변환
+    @Convert(converter = JsonAttributeConverter.class)
     @Column(name = "generated_subtitle", columnDefinition = "json")
-    private String generatedSubtitle;
+    private Map<String, Object> generatedSubtitle;
 
     @Column(name = "revised_full_content", columnDefinition = "TEXT")
     private String revisedFullContent;
@@ -70,7 +81,7 @@ public class ResumeAnalysisReport {
     private LocalDateTime updatedAt;
 
     @Builder
-    public ResumeAnalysisReport(Resume resume, Long jobPostingId) {
+    public ResumeAnalysisReport(Resume resume, JobPosting jobPostingId) {
         this.resume = resume;
         this.jobPostingId = jobPostingId;
         this.status = AnalysisStatus.PENDING;
@@ -82,7 +93,8 @@ public class ResumeAnalysisReport {
         this.status = AnalysisStatus.PROCESSING;
     }
 
-    public void completeAnalysis(Integer matchScore, String generatedSubtitle, String keywordAnalysis, String sentenceCorrection, String revisedFullContent) {
+    // public void completeAnalysis(Integer matchScore, String generatedSubtitle, String keywordAnalysis, String sentenceCorrection, String revisedFullContent) {
+    public void completeAnalysis(Integer matchScore, Map<String, Object> generatedSubtitle, Map<String, Object> keywordAnalysis, Map<String, Object> sentenceCorrection, String revisedFullContent) {
         this.matchScore = matchScore;
         this.generatedSubtitle = generatedSubtitle;
         this.keywordAnalysis = keywordAnalysis;

--- a/src/main/java/com/aibe/team2/domain/resume/service/ResumeAnalysisService.java
+++ b/src/main/java/com/aibe/team2/domain/resume/service/ResumeAnalysisService.java
@@ -1,16 +1,23 @@
 package com.aibe.team2.domain.resume.service;
 
+import com.aibe.team2.domain.jobposting.entity.JobPosting;
+import com.aibe.team2.domain.jobposting.repository.JobPostingRepository;
 import com.aibe.team2.domain.resume.entity.Resume;
 import com.aibe.team2.domain.resume.entity.ResumeAnalysisReport;
 import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
 import com.aibe.team2.domain.resume.repository.ResumeRepository;
 import com.aibe.team2.global.error.ErrorCode;
 import com.aibe.team2.global.exception.custom.NotFoundException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.aspectj.weaver.ast.Not;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -20,6 +27,10 @@ public class ResumeAnalysisService {
 
     private final ResumeRepository resumeRepository;
     private final ResumeAnalysisRepository resumeAnalysisRepository;
+    // [추가] 레포지토리 의존성 주입
+    private final JobPostingRepository jobPostingRepository;
+    // [추가] JSON 변환
+    private final ObjectMapper objectMapper;
 
     /**
      * 이력서 분석 요청 (Upsert Logic)
@@ -35,6 +46,10 @@ public class ResumeAnalysisService {
         // TODO: 추후 API 파라미터로 jobPostingId를 받아야 함. 현재는 1L(임시) 고정
         Long defaultJobPostingId = 1L;
 
+        // [추가] JobPosting 엔티티 조회
+        JobPosting jobPosting = jobPostingRepository.findById(defaultJobPostingId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMON_404));
+
         // 2. 기존 분석 이력 조회 (유니크 충돌 방지)
         // Repository에 findByResumeIdAndJobPostingId 메서드가 있다고 가정하거나,
         // 현재는 findTopBy...를 사용하여 최신건을 가져와 비교합니다.
@@ -43,7 +58,7 @@ public class ResumeAnalysisService {
 
         ResumeAnalysisReport report;
 
-        if (existingReport.isPresent() && existingReport.get().getJobPostingId().equals(defaultJobPostingId)) {
+        if (existingReport.isPresent() && existingReport.get().getJobPostingId().getId().equals(defaultJobPostingId)) {
             // 2-1. 이미 존재하는 리포트 -> 재분석 (Update)
             report = existingReport.get();
             report.startAnalysis(); // 상태를 PROCESSING으로 변경 및 갱신
@@ -52,7 +67,7 @@ public class ResumeAnalysisService {
             // 2-2. 새로운 리포트 생성 (Create)
             report = ResumeAnalysisReport.builder()
                     .resume(resume)
-                    .jobPostingId(defaultJobPostingId) // NOT NULL 제약조건 준수
+                    .jobPostingId(jobPosting) // NOT NULL 제약조건 준수
                     .build();
             report.startAnalysis(); // PROCESSING
             log.info("New analysis report created for resumeId: {}", resumeId);
@@ -66,14 +81,24 @@ public class ResumeAnalysisService {
             // 실제 구현 시 @Async 비동기 처리 권장
             AiAnalysisResult result = mockAiCall(resume.getContent());
 
+            // [추가] String(JSON) -> Map<String, Object> (역직렬화)
+            Map<String, Object> subtitleMap = objectMapper.readValue(result.generatedSubtitle(), new TypeReference<>(){});
+            Map<String, Object> keywordsMap = objectMapper.readValue(result.keywords(), new TypeReference<>(){});
+            Map<String, Object> correctionsMap = objectMapper.readValue(result.corrections(), new TypeReference<>(){});
+
             // 5. 분석 성공 처리 (데이터 업데이트)
             savedReport.completeAnalysis(
                     result.score,
-                    result.generatedSubtitle, // JSON
-                    result.keywords,          // JSON
-                    result.corrections,       // JSON
+                    subtitleMap, // [수정]
+                    keywordsMap,          // [수정]
+                    correctionsMap,       // [수정]
                     result.revisedContent
             );
+            // [추가] 역직렬화(JSON 변환) 실패 시
+        } catch(JsonProcessingException e) {
+            log.error("JSON parsing failed for resumeId: {}", resumeId, e);
+            savedReport.failAnalysis();
+
         } catch (Exception e) {
             log.error("AI Analysis failed for resumeId: {}", resumeId, e);
             savedReport.failAnalysis();
@@ -105,23 +130,44 @@ public class ResumeAnalysisService {
                 """;
 
         // 2. 키워드 분석 (JSON)
+        // [수정] JSON 배열에서 객체 형태로 변경
+        // String mockKeywordsJson = """
+        //         [
+        //             {"keyword": "Spring Boot", "count": 5, "importance": "HIGH"},
+        //             {"keyword": "JPA", "count": 3, "importance": "MEDIUM"},
+        //             {"keyword": "AWS", "count": 1, "importance": "LOW"}
+        //         ]
+        //         """;
         String mockKeywordsJson = """
-                [
-                    {"keyword": "Spring Boot", "count": 5, "importance": "HIGH"},
-                    {"keyword": "JPA", "count": 3, "importance": "MEDIUM"},
-                    {"keyword": "AWS", "count": 1, "importance": "LOW"}
-                ]
+                {
+                    "keywords": [
+                        {"keyword": "Spring Boot", "count": 5, "importance": "HIGH"},
+                        {"keyword": "JPA", "count": 3, "importance": "MEDIUM"},
+                        {"keyword": "AWS", "count": 1, "importance": "LOW"}
+                    ]
+                }
                 """;
 
         // 3. 문장 교정 (JSON)
+        // String mockCorrectionsJson = """
+        //         [
+        //             {
+        //                 "original": "열심히 했습니다.",
+        //                 "corrected": "주도적으로 프로젝트를 리딩하여 성과를 냈습니다.",
+        //                 "reason": "구체적인 성과 위주로 서술하는 것이 좋습니다."
+        //             }
+        //         ]
+        //         """;
         String mockCorrectionsJson = """
-                [
-                    {
-                        "original": "열심히 했습니다.",
-                        "corrected": "주도적으로 프로젝트를 리딩하여 성과를 냈습니다.",
-                        "reason": "구체적인 성과 위주로 서술하는 것이 좋습니다."
-                    }
-                ]
+                {
+                    "corrections": [
+                        {
+                            "original": "열심히 했습니다.",
+                            "corrected": "주도적으로 프로젝트를 리딩하여 성과를 냈습니다.",
+                            "reason": "구체적인 성과 위주로 서술하는 것이 좋습니다."
+                        }
+                    ]
+                }
                 """;
 
         // 4. 첨삭 완료 본문

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
@@ -1,0 +1,33 @@
+package com.aibe.team2.domain.statistics.controller;
+
+import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse;
+import com.aibe.team2.domain.statistics.service.InterviewStatisticsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage/interview")
+public class InterviewStatisticsController {
+
+    private final InterviewStatisticsService interviewStatisticsService;
+
+    // [FR-REP-04] 면접 이력 - 상세 조회(리포트)
+    @GetMapping("/{interviewId}")
+    public ResponseEntity<InterviewResultDetailResponse> getInterviewReport(
+            @PathVariable("interviewId") Long interviewId
+    ){
+        // TODO : 하드코딩 제거
+        // 임시 하드코딩된 사용자 ID
+        Long currenUserId = 1L;
+        InterviewResultDetailResponse response = interviewStatisticsService.getInterviewStatistics(interviewId, currenUserId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/ResumeStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/ResumeStatisticsController.java
@@ -1,0 +1,33 @@
+package com.aibe.team2.domain.statistics.controller;
+
+import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse;
+import com.aibe.team2.domain.statistics.service.ResumeStatisticsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage/resumes")
+public class ResumeStatisticsController {
+
+    private final ResumeStatisticsService resumeStatisticsService;
+
+    // [FR-REP-04] 자기소개서 첨삭 이력 - 상세 조회(리포트)
+    @GetMapping("/analysis/{analysisId}")
+    public ResponseEntity<ResumeAnalysisResultResponse> getResumeAnalysisReport(
+            @PathVariable("analysisId") Long analysisId
+    ){
+        // TODO : 하드코딩 제거
+        // 임시 하드코딩된 사용자 ID
+        Long currentUserId = 1L;
+        ResumeAnalysisResultResponse response = resumeStatisticsService.getResumeAnalysisReport(analysisId, currentUserId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/common/RadarChartStatResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/common/RadarChartStatResponse.java
@@ -1,0 +1,15 @@
+package com.aibe.team2.domain.statistics.dto.common;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RadarChartStatResponse {
+    private Double avgClarity;              // 평균 명확성
+    private Double avgPersuasiveness;       // 평균 설득력
+    private Double avgConsistency;          // 평균 일관성
+    private Double jobRelevanceScore;       // 직무 적합도 점수
+    private Double logicalStructureScore;   // 논리 구조 점수
+    private Double attitudeConfidenceScore; // 태도 및 자신감 점수
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewResultDetailResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewResultDetailResponse.java
@@ -1,0 +1,49 @@
+package com.aibe.team2.domain.statistics.dto.interview;
+
+import java.util.List;
+import java.util.Map;
+
+public record InterviewResultDetailResponse(
+        Long sessionId,
+        Integer totalScore,
+        String overallFeedback,
+
+        // [TODO] 차트 테이블 작성 시 주석 해제
+        // ChartMetricsDto chartMetrics,
+
+        LogicAndStructure logicAndStructure,
+        SpeechAnalysis speechAnalysis, // 발화 습관 및 비언어적 통계
+        List<TurnScript> turnScripts // 턴별 전체 대화 복기 스크립트
+) {
+    // 1. 답변 논리 및 구조
+    public record LogicAndStructure(
+            Integer clarityScore,
+            Integer persuasivenessScore,
+            Integer consistencyScore
+    ) {}
+
+    // 2. 비언어적 통계 집계 데이터
+    public record SpeechAnalysis(
+            Integer avgWpm,
+            Integer totalSilenceCount,
+            Float avgSttAccuracy,
+            Map<String, Object> emotionSummary,
+            List<String> habitDetails
+    ) {}
+
+    // 3. 대화 복기 및 개별 비언어 지표 (파라미터 10개 완벽 매칭)
+    public record TurnScript(
+            Integer turnSequence,
+            String questionText,
+            String answerText,
+            String aiFeedback,
+            Double evaluationScore,
+            List<String> recommendedGuides,
+
+            Integer wpm,
+            Integer silenceCount,
+            Float sttAccuracy,
+            Map<String, Object> emotionAnalysis,
+            Boolean isBookmarked
+    ) {}
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewScoreTrendResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewScoreTrendResponse.java
@@ -1,0 +1,17 @@
+package com.aibe.team2.domain.statistics.dto.interview;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record InterviewScoreTrendResponse(
+        Double averageScore, // 전체 평균 점수
+        Integer latestScore, // 가장 최근 점수
+        Double growthRate,   // 직전 대비 성장률 (+5.0, -2.0 등)
+        List<ScoreHistory> trendList // 그래프용 시계열 데이터
+) {
+    public record ScoreHistory(
+            Long sessionId,
+            Integer score,
+            LocalDateTime completedAt
+    ) {}
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/resume/ResumeAnalysisResultResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/resume/ResumeAnalysisResultResponse.java
@@ -1,0 +1,38 @@
+package com.aibe.team2.domain.statistics.dto.resume;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public record ResumeAnalysisResultResponse(
+        Long analysisId,
+        Integer totalScore, // 자소서 완성도 점수
+
+        EvaluationSummary evaluationSummary, // 상단 4대 지표 요약
+        KeywordStats keywordStats, // 상세 피드백 데이터
+        List<CorrectionDetail> sentenceCorrections, // 문장별 교정 데이터
+        Map<String, Object> generatedSubtitle,
+
+        String revisedFullContent, // AI 첨삭본 전체 텍스트
+        LocalDateTime analyzedAt
+) {
+    // 1. 상단 요약 지표 (가독성, 핵심 키워드 매칭, 논리적 설득력 등)
+    public record EvaluationSummary(
+            String readabilityLevel, // ex: "High"
+            Integer matchedKeywordCount,
+            Boolean isStarStructureApplied // STAR 기법 적용 여부
+    ) {}
+
+    // 2. 키워드 분석 데이터
+    public record KeywordStats(
+            List<String> goodKeywords,    // 많이 사용한 키워드
+            List<String> missingKeywords  // 추천 보완 키워드
+    ) {}
+
+    // 3. 문장별 교정 데이터 (Before & After 및 개선 포인트)
+    public record CorrectionDetail(
+            String originalSentence,
+            String correctedSentence,
+            String improvementReason // 왜 이렇게 고쳤는지
+    ) {}
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewRecord.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewRecord.java
@@ -1,0 +1,106 @@
+package com.aibe.team2.domain.statistics.entity;
+
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.global.converter.JsonAttributeConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Table(name = "interview_record")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class InterviewRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 다대일 연관관계 매핑(FK)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_session_id", nullable = false)
+    private InterviewSession interviewSession;
+
+    @Column(name = "turn_sequence")
+    private Integer turnSequence; // 대화 순서 (Turn)
+
+    @Column(name = "question_text", columnDefinition = "TEXT")
+    private String questionText; // 질문 내용
+
+    @Column(name = "question_intent", columnDefinition = "TEXT")
+    private String questionIntent; // 질문 의도
+
+    @Column(name = "answer_text", columnDefinition = "TEXT")
+    private String answerText; // 답변 내용
+
+    @Column(name = "follow_up_depth")
+    private Integer followUpDepth; // 꼬리질문 깊이
+
+    @Column(name = "s3_file_url", length = 500)
+    private String s3FileUrl; // 답변 음성 파일 URL
+
+    @Column(name = "wpm")
+    private Integer wpm; // 발화 속도 (Words Per Minute)
+
+    @Column(name = "stt_accuracy")
+    private Float sttAccuracy; // STT 정확도
+
+    @Column(name = "silence_count")
+    private Integer silenceCount; // 침묵 횟수
+
+    // 감정 분석 결과 JSON 데이터 (컨버터 재사용)
+    @Convert(converter = JsonAttributeConverter.class)
+    @Column(name = "emotion_analysis", columnDefinition = "json")
+    private Map<String, Object> emotionAnalysis;
+
+    @Column(name = "feedback_text", columnDefinition = "TEXT")
+    private String feedbackText; // 피드백 내용
+
+    @Column(name = "evaluation_score")
+    private Float evaluationScore; // 답변 평가 점수
+
+    @Column(name = "response_time_ms")
+    private Integer responseTimeMs; // 응답 소요 시간 (ms)
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public InterviewRecord(
+            InterviewSession interviewSession, Integer turnSequence, String questionText,
+            String questionIntent, String answerText, Integer followUpDepth,
+            String s3FileUrl, Integer wpm, Float sttAccuracy, Integer silenceCount,
+            Map<String, Object> emotionAnalysis, String feedbackText,
+            Float evaluationScore, Integer responseTimeMs
+    ){
+        this.interviewSession = interviewSession;
+        this.turnSequence = turnSequence;
+        this.questionText = questionText;
+        this.questionIntent = questionIntent;
+        this.answerText = answerText;
+        this.followUpDepth = followUpDepth;
+        this.s3FileUrl = s3FileUrl;
+        this.wpm = wpm;
+        this.sttAccuracy = sttAccuracy;
+        this.silenceCount = silenceCount;
+        this.emotionAnalysis = emotionAnalysis;
+        this.feedbackText = feedbackText;
+        this.evaluationScore = evaluationScore;
+        this.responseTimeMs = responseTimeMs;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewResultStatistics.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewResultStatistics.java
@@ -1,0 +1,85 @@
+package com.aibe.team2.domain.statistics.entity;
+
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.global.converter.JsonAttributeConverter;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Table(name = "interview_result_statistics")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class InterviewResultStatistics {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 면접 세션과 1:1 관계 매핑(FK)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interview_session_id", nullable = false)
+    private InterviewSession interviewSession;
+
+    // 차트용 6가지 지표
+    @Column(name = "avg_clarity")
+    private Double avgClarity;
+
+    @Column(name = "avg_persuasiveness")
+    private Double avgPersuasiveness;
+
+    @Column(name = "avg_consistency")
+    private Double avgConsistency;
+
+    @Column(name = "job_relevance_score")
+    private Double jobRelevanceScore;
+
+    @Column(name = "logical_structure_score")
+    private Double logicalStructureScore;
+
+    @Column(name = "attitude_confidence_score")
+    private Double attitudeConfidenceScore;
+
+    // 발화 습관 JSON 데이터
+    @Convert(converter = JsonAttributeConverter.class)
+    @Column(name = "speech_habits", columnDefinition = "json")
+    private Map<String, Object> speechHabits;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public InterviewResultStatistics(
+            InterviewSession interviewSession,
+            Double avgClarity,
+            Double avgPersuasiveness,
+            Double avgConsistency,
+            Double jobRelevanceScore,
+            Double logicalStructureScore,
+            Double attitudeConfidenceScore,
+            Map<String, Object> speechHabits
+    ){
+        this.interviewSession = interviewSession;
+        this.avgClarity = avgClarity;
+        this.avgPersuasiveness = avgPersuasiveness;
+        this.avgConsistency = avgConsistency;
+        this.jobRelevanceScore = jobRelevanceScore;
+        this.logicalStructureScore = logicalStructureScore;
+        this.attitudeConfidenceScore = attitudeConfidenceScore;
+        this.speechHabits = speechHabits;
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewRecordRepository.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewRecordRepository.java
@@ -1,0 +1,17 @@
+package com.aibe.team2.domain.statistics.repository;
+
+import com.aibe.team2.domain.statistics.entity.InterviewRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface InterviewRecordRepository extends JpaRepository<InterviewRecord, Long> {
+
+    // 특정 면접 세션의 모든 대화 기록을 대화 순서에 따라 정렬하여 조회
+    // @param sessionId 면접 세션 고유 ID
+    // @return 정렬된 대화 기록 리스트
+
+    List<InterviewRecord> findAllByInterviewSessionIdOrderByTurnSequenceAsc(Long interviewSessionId);
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepository.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepository.java
@@ -1,0 +1,15 @@
+package com.aibe.team2.domain.statistics.repository;
+
+import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface InterviewResultStatisticsRepository extends JpaRepository<InterviewResultStatistics, Long> {
+
+    // 특정 면접 세션 ID를 통해 통계 데이터 조회
+    // @param sessionId 면접 세션 고유 ID
+    // @return 해당 세션의 통계 데이터(Optional)
+
+    Optional <InterviewResultStatistics> findByInterviewSessionId(Long sessionId);
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
@@ -1,0 +1,118 @@
+package com.aibe.team2.domain.statistics.service;
+
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.repository.InterviewRepository;
+import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse;
+import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse.LogicAndStructure;
+import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse.SpeechAnalysis;
+import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse.TurnScript;
+import com.aibe.team2.domain.statistics.entity.InterviewRecord;
+import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import com.aibe.team2.domain.statistics.repository.InterviewRecordRepository;
+import com.aibe.team2.domain.statistics.repository.InterviewResultStatisticsRepository;
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.custom.ForbiddenException;
+import com.aibe.team2.global.exception.custom.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+// TODO : 하드코딩 제거
+public class InterviewStatisticsService {
+
+    private final InterviewRepository interviewRepository;
+    private final InterviewRecordRepository recordRepository;
+    private final InterviewResultStatisticsRepository statisticsRepository;
+
+    @Transactional(readOnly = true)
+    public InterviewResultDetailResponse getInterviewStatistics(Long sessionId, Long currentMemberId) {
+
+        // 1. 세션 조회
+        InterviewSession session = interviewRepository.findById(sessionId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMON_404));
+
+        // 2. 권한 검증 (스키마에 맞춰 getMemberId() 사용)
+        if (!session.getMemberId().equals(currentMemberId)) {
+            throw new ForbiddenException(ErrorCode.COMMON_403);
+        }
+
+        // 3. 기록 조회
+        List<InterviewRecord> records = recordRepository.findAllByInterviewSessionIdOrderByTurnSequenceAsc(sessionId);
+
+        // 4. 통계 엔티티 조회
+        InterviewResultStatistics stats = statisticsRepository.findByInterviewSessionId(sessionId).orElse(null);
+
+        // 5. 로직 및 구조 지표 매핑
+        LogicAndStructure logicAndStructure = new LogicAndStructure(
+                stats != null && stats.getAvgClarity() != null ? stats.getAvgClarity().intValue() : 0,
+                stats != null && stats.getAvgPersuasiveness() != null ? stats.getAvgPersuasiveness().intValue() : 0,
+                stats != null && stats.getAvgConsistency() != null ? stats.getAvgConsistency().intValue() : 0
+        );
+
+        // 6. 비언어 통계 집계 (메서드명 및 타입 매칭)
+        SpeechAnalysis speechAnalysis = calculateSpeechAnalysis(records);
+
+        // 7. 턴별 스크립트 매핑 (파라미터 10개 매칭)
+        List<TurnScript> turnScripts = records.stream()
+                .map(record -> new TurnScript(
+                        record.getTurnSequence(),
+                        record.getQuestionText(),
+                        record.getAnswerText(),
+                        record.getFeedbackText(),
+                        record.getEvaluationScore() != null ? record.getEvaluationScore().doubleValue() : 0.0,
+                        Collections.emptyList(),
+                        record.getWpm(),
+                        record.getSilenceCount(),
+                        record.getSttAccuracy(),
+                        record.getEmotionAnalysis(),
+                        false
+                ))
+                .toList();
+
+        // 6. 최종 응답
+        return new InterviewResultDetailResponse(
+                session.getId(),
+                session.getFinalScore(),
+                "전반적으로 직무에 대한 이해도가 높습니다.", // 임시 총평
+                logicAndStructure,
+                speechAnalysis,
+                turnScripts
+        );
+    }
+
+    // --- 내부 통계 집계 로직 ---
+    private SpeechAnalysis calculateSpeechAnalysis(List<InterviewRecord> records) {
+        if (records == null || records.isEmpty()) {
+            return new SpeechAnalysis(0, 0, 0.0f, null, Collections.emptyList());
+        }
+
+        int totalWpm = 0;
+        int totalSilence = 0;
+        float totalSttAccuracy = 0.0f;
+        int validTurnCount = records.size();
+
+        for (InterviewRecord record : records) {
+            totalWpm += (record.getWpm() != null ? record.getWpm() : 0);
+            totalSilence += (record.getSilenceCount() != null ? record.getSilenceCount() : 0);
+            totalSttAccuracy += (record.getSttAccuracy() != null ? record.getSttAccuracy() : 0.0f);
+        }
+
+        int avgWpm = totalWpm / validTurnCount;
+        float avgStt = totalSttAccuracy / validTurnCount;
+
+        return new SpeechAnalysis(
+                avgWpm,
+                totalSilence,
+                avgStt,
+                null, // 감정 분석 요약 임시 처리
+                Collections.emptyList()
+        );
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/service/ResumeStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/ResumeStatisticsService.java
@@ -1,0 +1,150 @@
+package com.aibe.team2.domain.statistics.service;
+
+import com.aibe.team2.domain.resume.entity.ResumeAnalysisReport;
+import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
+import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse;
+import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse.CorrectionDetail;
+import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse.EvaluationSummary;
+import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse.KeywordStats;
+import com.aibe.team2.global.common.constant.AnalysisStatus;
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.custom.ForbiddenException;
+import com.aibe.team2.global.exception.custom.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+// TODO : 하드코딩 부분 수정
+public class ResumeStatisticsService {
+
+    private final ResumeAnalysisRepository resumeAnalysisRepository;
+
+    // [FR-REP-04] 자기소개서 첨삭 이력 - 상세 조회
+    @Transactional(readOnly = true)
+    public ResumeAnalysisResultResponse getResumeAnalysisReport(Long analysisId, Long currentUserId) {
+
+        // 1. 분석 리포트 단건 조회(연관된 이력서 함께 조회 가정)
+        ResumeAnalysisReport report = resumeAnalysisRepository.findById(analysisId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMON_404));
+
+        // 2. 권한 검증
+        if(!report.getResume().getUserId().equals(currentUserId)){
+            throw new ForbiddenException(ErrorCode.COMMON_403);
+        }
+
+        // 3. 비즈니스 룰 처리
+        boolean isProcessing = report.getStatus() == AnalysisStatus.PROCESSING;
+
+        // 4. JSON 데이터 파싱 및 내부 Record 조립
+        List<String> goodKeywords = isProcessing ? Collections.emptyList() : extractGoodKeywords(report.getKeywordAnalysis());
+        List<String> missingKeywords = isProcessing ? Collections.emptyList() : extractMissingKeywords(report.getKeywordAnalysis());
+        List<CorrectionDetail> corrections = isProcessing ? Collections.emptyList() : extractCorrections(report.getSentenceCorrection());
+
+        // 4-1. 상단 요약 지표
+        EvaluationSummary summary = null;
+        if(!isProcessing){
+            summary = new EvaluationSummary(
+                    "High",
+                    goodKeywords.size(),
+                    true
+            );
+        }
+
+        // 4-2. 키워드 통계
+        KeywordStats keywordStats = isProcessing ? null : new KeywordStats(goodKeywords, missingKeywords);
+
+        // 5. 최종 DTO 반환
+        return new ResumeAnalysisResultResponse(
+                report.getId(),
+                isProcessing ? null : report.getMatchScore(),
+                summary,
+                keywordStats,
+                corrections,
+                isProcessing ? null : report.getGeneratedSubtitle(),
+                isProcessing ? null : report.getRevisedFullContent(), // After: 첨삭 완료된 자소서 본문
+                report.getCreatedAt()
+        );
+    }
+
+    // 내부 매핑 로직
+
+    // @SuppressWarnings("unchecked")
+    // private List<String> extractGoodKeywords(Map<String, Object> keywordMap){
+    //     if(keywordMap == null || !keywordMap.containsKey("keywords")){
+    //         return Collections.emptyList();
+    //     }
+    //     List<Map<String, Object>> list = (List<Map<String, Object>>) keywordMap.get("keywords");
+    //     return list.stream().map(k -> String.valueOf(k.get("keyword"))).toList();
+    // }
+    //
+    // @SuppressWarnings("unchecked")
+    // private List<String> extractMissingKeywords(Map<String, Object> keywordMap){
+    //     // 실제 JSON 구조에 "missingKeywords"키가 있을 경우를 대비한 로직
+    //     if(keywordMap != null && keywordMap.containsKey("missingKeywords")){
+    //         List<Map<String, Object>> missingList = (List<Map<String, Object>>) keywordMap.get("missingKeywords");
+    //         return missingList.stream().map(k -> String.valueOf(k.get("keyword"))).toList();
+    //     }
+    //     return List.of("대규모 트래픽", "시스템 설계"); // JSON 구조 확정 전 임시 데이터
+    // }
+    //
+    // @SuppressWarnings("unchecked")
+    // private List<CorrectionDetail> extractCorrections(Map<String, Object> correctionMap){
+    //     if(correctionMap == null || !correctionMap.containsKey("corrections")){
+    //         return Collections.emptyList();
+    //     }
+    //
+    //     List<Map<String, String>> list = (List<Map<String, String>>) correctionMap.get("corrections");
+    //     return list.stream()
+    //             .map(c -> new CorrectionDetail(
+    //                     c.get("original"),
+    //                     c.get("corrected"),
+    //                     c.get("reason")
+    //             )).toList();
+    // }
+
+    // --- 내부 매핑 로직 ---
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractGoodKeywords(Map<String, Object> keywordMap){
+        // DB JSON 구조: {"goodKeywords": ["분석력", "꾸준함"], ...}
+        if(keywordMap == null || !keywordMap.containsKey("goodKeywords")){
+            return Collections.emptyList();
+        }
+        // Map 객체가 아니라 순수 String 리스트이므로 바로 변환 후 반환
+        return (List<String>) keywordMap.get("goodKeywords");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> extractMissingKeywords(Map<String, Object> keywordMap){
+        // DB JSON 구조: {..., "missingKeywords": ["대규모 트래픽", "시스템 설계"]}
+        if(keywordMap == null || !keywordMap.containsKey("missingKeywords")){
+            return Collections.emptyList();
+        }
+        // Map 객체가 아니라 순수 String 리스트이므로 바로 변환 후 반환
+        return (List<String>) keywordMap.get("missingKeywords");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<CorrectionDetail> extractCorrections(Map<String, Object> correctionMap){
+        if(correctionMap == null || !correctionMap.containsKey("corrections")){
+            return Collections.emptyList();
+        }
+
+        List<Map<String, Object>> list = (List<Map<String, Object>>) correctionMap.get("corrections");
+        return list.stream()
+                .map(c -> new CorrectionDetail(
+                        // DB에 넣은 키값(originalSentence, correctedSentence)과 정확히 매칭
+                        String.valueOf(c.getOrDefault("originalSentence", "")),
+                        String.valueOf(c.getOrDefault("correctedSentence", "")),
+                        String.valueOf(c.getOrDefault("reason", ""))
+                )).toList();
+    }
+}

--- a/src/main/java/com/aibe/team2/global/converter/JsonAttributeConverter.java
+++ b/src/main/java/com/aibe/team2/global/converter/JsonAttributeConverter.java
@@ -1,0 +1,45 @@
+package com.aibe.team2.global.converter;
+
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.custom.JsonConversionException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Converter
+public class JsonAttributeConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 1. Entity 필드를 DB 컬럼으로 변환(직렬화)
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        if(attribute == null ||  attribute.isEmpty()) {
+            return null;
+        }
+
+        try{
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e){
+            throw new JsonConversionException(ErrorCode.COMMON_JSON_CONVERSION_ERROR);
+        }
+    }
+
+    // 2. DB 컬럼을 Entity 필드로 변환(역직렬화)
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        if(dbData == null || dbData.isEmpty()) {
+            return new HashMap<>();
+        }
+        try{
+            return objectMapper.readValue(dbData, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e){
+            throw new JsonConversionException(ErrorCode.COMMON_JSON_CONVERSION_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/aibe/team2/global/error/ErrorCode.java
+++ b/src/main/java/com/aibe/team2/global/error/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     COMMON_405(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_405", "지원하지 않는 HTTP 메서드입니다."),
     COMMON_409(HttpStatus.CONFLICT, "COMMON_409", "요청이 현재 상태와 충돌합니다."),
     COMMON_500(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 내부 오류가 발생했습니다."),
+    COMMON_JSON_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_501", "JSON 데이터 변환 중 오류가 발생했습니다."),
 
     // Auth(인증)
     AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_001", "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/aibe/team2/global/exception/custom/JsonConversionException.java
+++ b/src/main/java/com/aibe/team2/global/exception/custom/JsonConversionException.java
@@ -1,0 +1,11 @@
+package com.aibe.team2.global.exception.custom;
+
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.BusinessException;
+
+public class JsonConversionException extends BusinessException {
+
+    public JsonConversionException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closed: #37 

## 작업 내용
- JSON Converter 구현 : `Jackson` 라이브러리를 활용해 JSON 데이터를 객체로 반환하는 `JsonAttributeConverter` 및 커스텀 예외 `JsonConversionException` 구현
- 엔티티 `@Convert` 적용 : `InterviewRecord`, `ResumeAnalysisReport` 등 JSON 형태의 데이터를 저장하는 엔티티 필드에 컨버터 적용
- 통계 전용 신규 엔티티 설계 : 레이더 차트용 지표 및 복합 데이터를 포함하는 `InterviewResultStatistics` 엔티티 및 레포지토리 추가
- 응답용 DTO 클래스 구현 : 이력서 분석 결과(`ResumeAnalysisResponse`), 면접 상세 결과(`InterviewResultDetailResponse`), 점수 추이(`InterviewScoreTrendResponse`) 등 통계 및 리포트 반환용 DTO 설계
- 누락된 컬럼 추가 : `InterviewSession` 엔티티에 필수 컬럼(`final_score`, `created_at`) 추가 및 매핑

<br/>

## 변경 사항 및 주의 사항
- N+1 문제 방지 : 신규 추가된 `InterviewResultStatistics`와 기존 `InterviewSession` 간의 1:1 매핑 시, 불필요한 쿼리 발생을 막기 위해 `FetchType.LAZY` 적용
- 순환 참조 방지 : 엔티티를 컨트롤러에서 직접 반환하지 않고, 반드시 새롭게 설계한 DTO로 변환하여 응답하도록 구성
- 예외처리 : JSON 파싱 중 발생하는 `JsonProcessingException`을 커스텀 예외로 래핑하고, `ErrorCode`에 관련 에러 코드를 추가하여 명확한 로그를 남기도록 처리
- 작업 범위 분리 : '회원 통계' 및 '월간 사용량'과 관련된 부분은 추후에 추가 예정
- 레이더 차트용 6대 지표 관련해 항목 추가 예정

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #37 
