### PR TITLE
[FEAT] 통계 로직 검증을 위한 더미 데이터 생성 모듈 구현 및 단위 테스트 완료

### DIFF
--- a/src/main/java/com/aibe/team2/domain/resume/entity/ResumeAnalysisReport.java
+++ b/src/main/java/com/aibe/team2/domain/resume/entity/ResumeAnalysisReport.java
@@ -51,18 +51,18 @@ public class ResumeAnalysisReport {
     // JSON 타입 (MySQL 등에서 JSON 컬럼 사용 시 columnDefinition 명시 권장)
     // ⭐ Convert 어노테이션 추가 및 Map<String, Object> 변환
     @Convert(converter = JsonAttributeConverter.class)
-    @Column(name = "keyword_analysis", columnDefinition = "json")
+    @Column(name = "keyword_analysis", columnDefinition = "TEXT")
     private Map<String, Object> keywordAnalysis;
 
     // ⭐ Convert 어노테이션 추가 및 Map<String, Object> 변환
     @Convert(converter = JsonAttributeConverter.class)
-    @Column(name = "sentence_correction", columnDefinition = "json")
+    @Column(name = "sentence_correction", columnDefinition = "TEXT")
     private Map<String, Object> sentenceCorrection;
 
     // New! 이미지 반영: JSON 타입
     // ⭐ Convert 어노테이션 추가 및 Map<String, Object> 변환
     @Convert(converter = JsonAttributeConverter.class)
-    @Column(name = "generated_subtitle", columnDefinition = "json")
+    @Column(name = "generated_subtitle", columnDefinition = "TEXT")
     private Map<String, Object> generatedSubtitle;
 
     @Column(name = "revised_full_content", columnDefinition = "TEXT")

--- a/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewRecord.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewRecord.java
@@ -59,7 +59,7 @@ public class InterviewRecord {
 
     // 감정 분석 결과 JSON 데이터 (컨버터 재사용)
     @Convert(converter = JsonAttributeConverter.class)
-    @Column(name = "emotion_analysis", columnDefinition = "json")
+    @Column(name = "emotion_analysis", columnDefinition = "TEXT")
     private Map<String, Object> emotionAnalysis;
 
     @Column(name = "feedback_text", columnDefinition = "TEXT")

--- a/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewResultStatistics.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewResultStatistics.java
@@ -51,7 +51,7 @@ public class InterviewResultStatistics {
 
     // 발화 습관 JSON 데이터
     @Convert(converter = JsonAttributeConverter.class)
-    @Column(name = "speech_habits", columnDefinition = "json")
+    @Column(name = "speech_habits", columnDefinition = "TEXT")
     private Map<String, Object> speechHabits;
 
     @CreatedDate

--- a/src/main/java/com/aibe/team2/global/init/DataInitializer.java
+++ b/src/main/java/com/aibe/team2/global/init/DataInitializer.java
@@ -1,0 +1,200 @@
+package com.aibe.team2.global.init;
+
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.repository.InterviewRepository;
+import com.aibe.team2.domain.jobposting.entity.JobPosting;
+import com.aibe.team2.domain.jobposting.repository.JobPostingRepository;
+import com.aibe.team2.domain.mypage.entity.Member;
+import com.aibe.team2.domain.mypage.repository.MemberRepository;
+import com.aibe.team2.domain.resume.entity.Resume;
+import com.aibe.team2.domain.resume.entity.ResumeAnalysisReport;
+import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
+import com.aibe.team2.domain.resume.repository.ResumeRepository;
+import com.aibe.team2.domain.statistics.entity.InterviewRecord;
+import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import com.aibe.team2.domain.statistics.repository.InterviewRecordRepository;
+import com.aibe.team2.domain.statistics.repository.InterviewResultStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Slf4j
+@Component
+@Profile("!prod") // 로컬이나 개발 환경에서만 이 빈이 활성화됨
+@RequiredArgsConstructor
+public class DataInitializer implements CommandLineRunner {
+
+    private final MemberRepository memberRepository;
+    private final InterviewRepository interviewRepository;
+    private final InterviewRecordRepository interviewRecordRepository;
+    private final InterviewResultStatisticsRepository statisticsRepository;
+
+    private final ResumeRepository resumeRepository;
+    private final JobPostingRepository jobPostingRepository;
+    private final ResumeAnalysisRepository resumeAnalysisRepository;
+
+   @Override
+    @Transactional
+    public void run(String... args) throws Exception {
+
+       if(memberRepository.count() > 0){
+           log.info("더미 데이터가 이미 존재하여 생성을 건너뜁니다.");
+           return;
+       }
+
+       log.info("---전체 도메인 더미 데이터 생성을 시작합니다.---");
+       Random random = new Random();
+
+       // 1. 멤버 5명 생성
+       List<Member> members = createMembers();
+
+       for(Member member : members) {
+           Long userId = member.getId();
+
+           // 2. 이력서 및 채용공고 생성(부모 데이터)
+           Resume resume = createResume(userId);
+           JobPosting jobPosting = createJobPosting(userId);
+
+           // 3. 이력서 분석 결과 생성(자식 데이터)
+           createResumeAnalysisReport(resume, jobPosting);
+
+           // 4. 회우너별 면접 세션 및 통계 데이터 생성(5~10건)
+           int sessionCount = random.nextInt(6) + 5;
+           for (int i = 0; i < sessionCount; i++){
+
+               int daysAgo = random.nextInt(60) + 1;
+               LocalDateTime pastDate = LocalDateTime.now().minusDays(daysAgo);
+
+               // 4-1. InterviewSession
+               InterviewSession session = InterviewSession.builder()
+                       .memberId(userId)
+                       .type(i % 2 == 0 ? "TEXT" : "VOICE")
+                       .build();
+
+               setCreatedAt(session, pastDate);
+               interviewRepository.save(session);
+
+               // 4-2. InterviewRecord
+               Map<String, Object> emotionDummy = new HashMap<>();
+               emotionDummy.put("confidence", random.nextDouble());
+               emotionDummy.put("anxiety", random.nextDouble());
+
+               InterviewRecord record = InterviewRecord.builder()
+                       .interviewSession(session)
+                       .turnSequence(1)
+                       .questionText("Spring Boot의 장점은 무엇인가요?")
+                       .answerText("의존성 관리가 편리하고 내장 톰캣을 제공하여...")
+                       .emotionAnalysis(emotionDummy)
+                       .evaluationScore((float) (random.nextInt(41)+60)) // 60~100점 사이로 분산
+                       .build();
+
+               setCreatedAt(record, pastDate);
+               interviewRecordRepository.save(record);
+
+               // 4-3. InterviewResultStatistics
+               Map<String, Object> habitDummy = new HashMap<>();
+               habitDummy.put("filler_words", random.nextInt(5));
+
+               InterviewResultStatistics stats = InterviewResultStatistics.builder()
+                       .interviewSession(session)
+                       .avgClarity(random.nextDouble() * 100)
+                       .avgPersuasiveness(random.nextDouble() * 100)
+                       .avgConsistency(random.nextDouble() * 100)
+                       .jobRelevanceScore(random.nextDouble() * 100)
+                       .logicalStructureScore(random.nextDouble() * 100)
+                       .attitudeConfidenceScore(random.nextDouble() * 100)
+                       .speechHabits(habitDummy)
+                       .build();
+               setCreatedAt(stats, pastDate);
+               statisticsRepository.save(stats);
+           }
+       }
+
+       log.info("더미 데이터 생성이 성공적으로 완료되었습니다.");
+   }
+
+   // 데이터 생성 모듈
+    private List<Member> createMembers() {
+       List<Member> members = new ArrayList<>();
+       for(int i = 1; i <= 5; i++){
+           Member member = new Member(
+                   "tester" + i + "@synctalk.com",
+                   "encodedPassword!",
+                   "테스터" + i,
+                   null, null
+           );
+           members.add(memberRepository.save(member));
+       }
+       return members;
+    }
+
+    private Resume createResume(Long userId) {
+       Resume resume = Resume.builder()
+               .userId(userId)
+               .title("백엔드 개발자 지원 이력서")
+               .content("저는 Java와 Spring을 활용한 프로젝트 경험이 있습니다. ...")
+               .s3FileUrl("https://s3.ap-northeast-2.amazonaws.com/synctalk/dummy.pdf")
+               .build();
+       resume.updateAnalysisStatus(true);
+       return resumeRepository.save(resume);
+    }
+
+    private JobPosting createJobPosting(Long userId) {
+        String jsonSkills = "[\"Java\", \"Spring Boot\", \"JPA\", \"MySQL\"]";
+        JobPosting jobPosting = JobPosting.builder()
+                .userId(userId)
+                .companyName("싱크테크")
+                .jobTitle("주니어 백엔드 엔지니어")
+                .jobDescription("대용량 트래픽 처리를 경험할 백엔드 개발자를 모십니다.")
+                .requiredSkills(jsonSkills)
+                .build();
+        return jobPostingRepository.save(jobPosting);
+    }
+
+    private void createResumeAnalysisReport(Resume resume, JobPosting jobPosting) {
+        ResumeAnalysisReport report = ResumeAnalysisReport.builder()
+                .resume(resume)
+                .jobPostingId(jobPosting)
+                .build();
+
+        Map<String, Object> generatedSubtitle = new HashMap<>();
+        generatedSubtitle.put("title", "기본기가 탄탄한 스프링 개발자");
+
+        Map<String, Object> keywordAnalysis = new HashMap<>();
+        keywordAnalysis.put("matched_keywords", List.of("Java", "Spring Boot", "JPA", "MySQL"));
+        keywordAnalysis.put("missing_keywords", List.of("Redis"));
+
+        Map<String, Object> sentenceCorrection = new HashMap<>();
+        sentenceCorrection.put("original", "경험이 있습니다.");
+        sentenceCorrection.put("corrected", "다양한 실무 프로젝트를 통해 경험을 쌓았습니다.");
+
+        report.startAnalysis();
+        report.completeAnalysis(
+                85,
+                generatedSubtitle,
+                keywordAnalysis,
+                sentenceCorrection,
+                "첨삭이 완료된 전체 이력서 내용입니다. ..."
+        );
+
+        resumeAnalysisRepository.save(report);
+    }
+
+    // 자바 리플렉션을 통해 생성일자를 강제로 덮어씌움
+    private void setCreatedAt(Object entity, LocalDateTime pastDate){
+       try{
+           Field createdAtField = entity.getClass().getDeclaredField("createdAt");
+           createdAtField.setAccessible(true);
+           createdAtField.set(entity, pastDate);
+       } catch (NoSuchFieldException | IllegalAccessException e) {
+           log.error("과거 날짜 주입 중 리플렉션 에러 발생", e);
+       }
+    }
+}

--- a/src/test/java/com/aibe/team2/global/init/DummyDataRetrievalTest.java
+++ b/src/test/java/com/aibe/team2/global/init/DummyDataRetrievalTest.java
@@ -1,0 +1,57 @@
+package com.aibe.team2.global.init;
+
+import com.aibe.team2.domain.statistics.dto.common.RadarChartStatResponse;
+import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import com.aibe.team2.domain.statistics.repository.InterviewResultStatisticsRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest(properties = {
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379"
+})
+@ActiveProfiles("local")
+@Transactional
+public class DummyDataRetrievalTest {
+
+   @Autowired
+   private InterviewResultStatisticsRepository statisticsRepository;
+
+   @Test
+    @DisplayName("DB에 적재된 통계 더미 데이터가 RadarChartStatResponse DTO로 정상 변환된다.")
+    void testDummyDataRetrievalAndDtoMapping(){
+       // [Given]  DataInitializer에 의해 생성된 더미 데이터를 DB에서 전체 조회
+       List<InterviewResultStatistics> statsList = statisticsRepository.findAll();
+
+       // DB에 데이터가 1건 이상 존재하는지 확인(더미 데이터 생성 로직 검증)
+       assertFalse(statsList.isEmpty(), "데이터베이스에 더미 데이터가 존재하지 않습니다.");
+       InterviewResultStatistics entity = statsList.get(0); // 테스트를 위해 첫 번째 통계 데이터 추출
+
+       // [When]  Entity 객체를 클라이언트 반환용 DTO 객체로 변환(Mapping)
+       RadarChartStatResponse dto = RadarChartStatResponse.builder()
+               .avgClarity(entity.getAvgClarity())
+               .avgPersuasiveness(entity.getAvgPersuasiveness())
+               .avgConsistency(entity.getAvgConsistency())
+               .jobRelevanceScore(entity.getJobRelevanceScore())
+               .logicalStructureScore(entity.getLogicalStructureScore())
+               .attitudeConfidenceScore(entity.getAttitudeConfidenceScore())
+               .build();
+
+       // [Then] 변환된 DTO의 무결성 검증
+       assertNotNull(dto, "DTO 반환 결과가 null입니다.");
+       assertEquals(entity.getAvgClarity(), dto.getAvgClarity());
+       assertEquals(entity.getJobRelevanceScore(), dto.getJobRelevanceScore());
+
+       log.info("DTO 매핑 성공! 조회된 명확성 평균 점수 : {}", dto.getAvgClarity());
+   }
+}


### PR DESCRIPTION
## 관련 이슈
- closed: #38 

## 작업 내용
- `DataInitializer` 클래스 구현 : 로컬 및 개발 환경(`!prod`) 전용 대량 더미 데이터 자동 삽입 모듈 추가
- 데이터 무결성 준수 : 사용자(5명) -> 이력서 및 채용 공고 -> 면접 세션(5~10건) -> 모의 면접 기록 및 통계 데이터 순으로 외래키 제약 조건에 맞춰 데이터 생성
- 시계열 데이터 처리 : 통계 로직 테스트를 위해 자바 리플렉션을 활용해 `createdAt` 필드에 1~60일 전 과거 날짜를 랜덤으로 강제 주입
- DTO 매핑 검증 : 생성된 통계 더미 데이터가 클라이언트 응답용 `RadarChartStatResponse` DTO로 정상 매핑 및 조회되는지 확인하는 단위 테스트 `DummyDataRetrievalTest` 작성 및 통과

<br/>

## 변경 사항 및 주의 사항
**⭐ JSON 매핑 컬럼 타입을 `TEXT`로 일괄 변경(`columnDefinition = "TEXT"`) ⭐**
- 사유 : 테스트 환경인 H2 DB에서 `json` 타입 컬럼을 조회할 때, `JsonAttributeConverter`와 데이터 타입 충돌로 인해 파싱 에러(`JsonConversionException`)가 발생
- 해결 : MySQL(운영)과 H2(테스트) 양쪽 모두에서 안전하게 순수 문자열로 동작할 수 있도록 범용적인 `TEXT` 타입으로 속성 변경
- 적용 대상 (수정된 엔티티 파일)
  - 📂 `statistics` 도메인
    - `InterviewResultStatistics.java` (`speech_habits` 필드)
    - `InterviewRecord.java` (`emotion_analysis` 필드)
  - 📂 `resume` 도메인
    - `ResumeAnalysisReport.java` (`keyword_analysis`, `sentence_correction`, `generated_subtitle` 필드)
- 주의 요망: 향후 다른 도메인 엔티티에서 JSON 컨버터를 사용하실 때에도 DB 환경 호환성을 위해 `TEXT` 타입을 사용해 주시길 권장합니다. (팀 트러블슈팅 문서에 관련 내용 기재 완료)

**단위 테스트 환경의 외부 인프라 의존성 격리**
- `@SpringBootTest` 컨텍스트 로드 시 Redis 설정(`spring.data.redis.host`) 누락으로 인한 컨테이너 초기화 실패를 방지하기 위해, 테스트 클래스단에 임시 프로퍼티를 주입하여 환경을 격
<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
