### PR TITLE
[FEAT] 통계 상세 조회 및 목록 조회 API 구현 (QueryDSL 연동)

### DIFF
--- a/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -14,10 +15,12 @@ import java.time.LocalDateTime;
 @Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     private Long id;
 
     @Column(nullable = false, unique = true)
@@ -69,30 +72,21 @@ public class Member {
         this.nickname = nickname;
         this.role = role != null ? role : Role.MEMBER;
         this.provider = provider;
-
         this.subscriptionPlan = SubscriptionPlan.FREE;
         this.creditBalance = 0;
-
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void updateProfile(String nickname, String profileImageUrl) {
-        if(nickname != null && !nickname.isEmpty())
-            this.nickname = nickname;
-        if(profileImageUrl != null && !profileImageUrl.isEmpty())
-            this.profileImageUrl = profileImageUrl;
-        this.updatedAt = LocalDateTime.now();
+        if (nickname != null && !nickname.isEmpty()) this.nickname = nickname;
+        if (profileImageUrl != null && !profileImageUrl.isEmpty()) this.profileImageUrl = profileImageUrl;
     }
 
     public void updatePassword(String encodedNewPassword) {
         this.password = encodedNewPassword;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void updateJobPreferences(String desiredJobRole, String preferredLocation) {
         this.desiredJobRole = desiredJobRole;
         this.preferredLocation = preferredLocation;
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
@@ -1,30 +1,53 @@
 package com.aibe.team2.domain.statistics.controller;
 
+import com.aibe.team2.domain.statistics.dto.common.RadarChartStatResponse;
 import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse;
 import com.aibe.team2.domain.statistics.service.InterviewStatisticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
+@Tag(name = "통계/이력 API", description = "면접 결과 통계 및 이력 조회 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/mypage/interview")
+@RequestMapping("/api/v1/mypage/interviews")
 public class InterviewStatisticsController {
 
     private final InterviewStatisticsService interviewStatisticsService;
 
+    // [FR-REP-04] 면접 이력 - 목록 조회(다건)
+    // 쿼리 파라미터로 sessionType 필터링
+    @Operation(summary = "내 면접 이력 목록 조회", description = "사용자의 전체 면접 이력과 통계 요약 정보를 리스트로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<RadarChartStatResponse>> getInterviewList(
+            @RequestParam(required = false) String sessionType
+            // TODO : Spring Security 연동
+            // @AuthenticationPrincipal CustomUserDetails userDetails
+    ){
+        // TODO : Spring Security 연동
+        // Long currentUserId = userDetails.getId();
+        Long currentUserId = 1L;
+        List<RadarChartStatResponse> response = interviewStatisticsService.getInterviewStatisticsList(currentUserId, sessionType);
+
+        return ResponseEntity.ok(response);
+    }
+
     // [FR-REP-04] 면접 이력 - 상세 조회(리포트)
+    @Operation(summary = "면접 상세 결과 조회", description = "특정 면접 세션의 상세 대화 내용, 평가 점수, 피드백 등을 조회합니다. ")
     @GetMapping("/{interviewId}")
     public ResponseEntity<InterviewResultDetailResponse> getInterviewReport(
             @PathVariable("interviewId") Long interviewId
+            // TODO : Spring Security 연동
+            // @AuthenticationPrincipal CustomUserDetails userDetails
     ){
-        // TODO : 하드코딩 제거
-        // 임시 하드코딩된 사용자 ID
+        // TODO : Spring Security 연동
+        // Long currentUserId = userDetails.getId();
         Long currenUserId = 1L;
         InterviewResultDetailResponse response = interviewStatisticsService.getInterviewStatistics(interviewId, currenUserId);
 

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
@@ -48,8 +48,8 @@ public class InterviewStatisticsController {
     ){
         // TODO : Spring Security 연동
         // Long currentUserId = userDetails.getId();
-        Long currenUserId = 1L;
-        InterviewResultDetailResponse response = interviewStatisticsService.getInterviewStatistics(interviewId, currenUserId);
+        Long currentUserId = 1L;
+        InterviewResultDetailResponse response = interviewStatisticsService.getInterviewStatistics(interviewId, currentUserId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewResultStatistics.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewResultStatistics.java
@@ -49,6 +49,9 @@ public class InterviewResultStatistics {
     @Column(name = "attitude_confidence_score")
     private Double attitudeConfidenceScore;
 
+    @Column(name = "overall_feedback", columnDefinition = "TEXT")
+    private String overallFeedback;
+
     // 발화 습관 JSON 데이터
     @Convert(converter = JsonAttributeConverter.class)
     @Column(name = "speech_habits", columnDefinition = "TEXT")
@@ -71,6 +74,7 @@ public class InterviewResultStatistics {
             Double jobRelevanceScore,
             Double logicalStructureScore,
             Double attitudeConfidenceScore,
+            String overallFeedback,
             Map<String, Object> speechHabits
     ){
         this.interviewSession = interviewSession;
@@ -80,6 +84,7 @@ public class InterviewResultStatistics {
         this.jobRelevanceScore = jobRelevanceScore;
         this.logicalStructureScore = logicalStructureScore;
         this.attitudeConfidenceScore = attitudeConfidenceScore;
+        this.overallFeedback = overallFeedback;
         this.speechHabits = speechHabits;
     }
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepository.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepository.java
@@ -5,7 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface InterviewResultStatisticsRepository extends JpaRepository<InterviewResultStatistics, Long> {
+public interface InterviewResultStatisticsRepository
+        extends JpaRepository<InterviewResultStatistics, Long>, InterviewResultStatisticsRepositoryCustom {
 
     // 특정 면접 세션 ID를 통해 통계 데이터 조회
     // @param sessionId 면접 세션 고유 ID

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepositoryCustom.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.aibe.team2.domain.statistics.repository;
+
+import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+
+import java.util.List;
+
+public interface InterviewResultStatisticsRepositoryCustom {
+
+    // 특정 회원의 통계 결화를 조회하며, 면접 타입(TEXT/VOICE)에 따라 동적 필터링을 수행
+    List<InterviewResultStatistics> findStatisticsByCondition(Long memberId, String sessionType);
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepositoryImpl.java
@@ -36,7 +36,10 @@ public class InterviewResultStatisticsRepositoryImpl implements InterviewResultS
     // 동적 쿼리를 위한 BooleanExpression 메서드
     // 1. 회원 ID 일치 여부(필수 조건)
     private BooleanExpression memberIdEq(Long memberId) {
-        return memberId != null ? interviewSession.memberId.eq(memberId) : null;
+        if(memberId == null){
+            throw new IllegalArgumentException("회원 ID는 필수입니다.");
+        }
+        return interviewSession.memberId.eq(memberId);
     }
 
     // 2. 면접 타입 일치 여부(동적 조건)

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.aibe.team2.domain.statistics.repository;
+
+import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.aibe.team2.domain.interview.entity.QInterviewSession.interviewSession;
+import static com.aibe.team2.domain.statistics.entity.QInterviewResultStatistics.interviewResultStatistics;
+
+@Repository
+@RequiredArgsConstructor
+public class InterviewResultStatisticsRepositoryImpl implements InterviewResultStatisticsRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<InterviewResultStatistics> findStatisticsByCondition(Long memberId, String sessionType) {
+        return queryFactory
+                .selectFrom(interviewResultStatistics)
+                // 연관된 면접 세션 테이블과 조인(회원 ID 및 타입 검사를 위해)
+                .join(interviewResultStatistics.interviewSession, interviewSession)
+                .where(
+                        memberIdEq(memberId), // 필수 조건
+                        sessionTypeEq(sessionType) // 동적 조건(null이면 무시됨)
+                )
+                // 최신 면접 결과부터 나오도록 내림차순 정렬
+                .orderBy(interviewResultStatistics.createdAt.desc())
+                .fetch();
+    }
+
+    // 동적 쿼리를 위한 BooleanExpression 메서드
+    // 1. 회원 ID 일치 여부(필수 조건)
+    private BooleanExpression memberIdEq(Long memberId) {
+        return memberId != null ? interviewSession.memberId.eq(memberId) : null;
+    }
+
+    // 2. 면접 타입 일치 여부(동적 조건)
+    private BooleanExpression sessionTypeEq(String sessionType) {
+        // StringUtils.hasText()를 통해 null 또는 빈 문자열을 한 번에 검증
+        return StringUtils.hasText(sessionType) ? interviewSession.type.eq(sessionType) : null;
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
@@ -2,6 +2,7 @@ package com.aibe.team2.domain.statistics.service;
 
 import com.aibe.team2.domain.interview.entity.InterviewSession;
 import com.aibe.team2.domain.interview.repository.InterviewRepository;
+import com.aibe.team2.domain.statistics.dto.common.RadarChartStatResponse;
 import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse;
 import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse.LogicAndStructure;
 import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse.SpeechAnalysis;
@@ -19,18 +20,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-// TODO : 하드코딩 제거
 public class InterviewStatisticsService {
 
     private final InterviewRepository interviewRepository;
     private final InterviewRecordRepository recordRepository;
     private final InterviewResultStatisticsRepository statisticsRepository;
 
+    // [단건 상세 조회]
     @Transactional(readOnly = true)
     public InterviewResultDetailResponse getInterviewStatistics(Long sessionId, Long currentMemberId) {
 
@@ -71,26 +74,45 @@ public class InterviewStatisticsService {
                         record.getWpm(),
                         record.getSilenceCount(),
                         record.getSttAccuracy(),
-                        record.getEmotionAnalysis(),
+                        formatEmotionMap(record.getEmotionAnalysis()),
                         false
                 ))
                 .toList();
 
-        // 6. 최종 응답
+        // 8. 최종 응답
+        String overallReview = "";
+
         return new InterviewResultDetailResponse(
                 session.getId(),
                 session.getFinalScore(),
-                "전반적으로 직무에 대한 이해도가 높습니다.", // 임시 총평
+                overallReview,// 임시 총평
                 logicAndStructure,
                 speechAnalysis,
                 turnScripts
         );
     }
 
+    // [다건 목록 동적 조회]
+    @Transactional(readOnly = true)
+    public List<RadarChartStatResponse> getInterviewStatisticsList(Long currentMemberId, String sessionType) {
+
+        List<InterviewResultStatistics> statsList = statisticsRepository.findStatisticsByCondition(currentMemberId, sessionType);
+        return statsList.stream()
+                .map(stat -> RadarChartStatResponse.builder() // 💡 빌더 패턴 사용
+                        .avgClarity(formatScore(stat.getAvgClarity()))
+                        .avgPersuasiveness(formatScore(stat.getAvgPersuasiveness()))
+                        .avgConsistency(formatScore(stat.getAvgConsistency()))
+                        .jobRelevanceScore(formatScore(stat.getJobRelevanceScore()))
+                        .logicalStructureScore(formatScore(stat.getLogicalStructureScore()))
+                        .attitudeConfidenceScore(formatScore(stat.getAttitudeConfidenceScore()))
+                        .build())
+                .toList();
+    }
+
     // --- 내부 통계 집계 로직 ---
     private SpeechAnalysis calculateSpeechAnalysis(List<InterviewRecord> records) {
         if (records == null || records.isEmpty()) {
-            return new SpeechAnalysis(0, 0, 0.0f, null, Collections.emptyList());
+            return new SpeechAnalysis(0, 0, 0.0f, Collections.emptyMap(), Collections.emptyList());
         }
 
         int totalWpm = 0;
@@ -104,15 +126,52 @@ public class InterviewStatisticsService {
             totalSttAccuracy += (record.getSttAccuracy() != null ? record.getSttAccuracy() : 0.0f);
         }
 
-        int avgWpm = totalWpm / validTurnCount;
-        float avgStt = totalSttAccuracy / validTurnCount;
+        int avgWpm = validTurnCount > 0 ? totalWpm / validTurnCount : 0;
+        float rawAvgStt = validTurnCount > 0 ? totalSttAccuracy / validTurnCount : 0.0f;
+        float avgStt = (float) (Math.round(rawAvgStt * 100.0) / 100.0);
+
+        Map<String, Object> emotionMap = records.get(0).getEmotionAnalysis();
+        Map<String, Object> formattedEmotionMap = formatEmotionMap(emotionMap);
 
         return new SpeechAnalysis(
                 avgWpm,
                 totalSilence,
                 avgStt,
-                null, // 감정 분석 요약 임시 처리
+                formattedEmotionMap,
                 Collections.emptyList()
         );
+    }
+
+    // 소수점 첫째 자리 반올림 메서드
+    private Double formatScore(Double score){
+        if(score == null) return 0.0;
+        return Math.round(score*10) / 10.0;
+    }
+
+    // 감정 분석 Map 값 반올림(소수점 둘째 자리)
+    private Map<String, Object> formatEmotionMap(Map<String, Object> emotionMap) {
+        if (emotionMap == null || emotionMap.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Object> formattedMap = new HashMap<>();
+
+        // 맵의 모든 키-값을 하나씩 꺼내서 확인
+        for (Map.Entry<String, Object> entry : emotionMap.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            // 만약 값이 숫자(Double, Float 등)라면?
+            if (value instanceof Number) {
+                double doubleVal = ((Number) value).doubleValue();
+                // 소수점 둘째 자리까지 반올림 (예: 0.9267 -> 0.93)
+                double roundedVal = Math.round(doubleVal * 100.0) / 100.0;
+                formattedMap.put(key, roundedVal);
+            } else {
+                // 숫자가 아니면 그냥 원래 값 넣기
+                formattedMap.put(key, value);
+            }
+        }
+        return formattedMap;
     }
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
@@ -80,7 +80,8 @@ public class InterviewStatisticsService {
                 .toList();
 
         // 8. 최종 응답
-        String overallReview = "";
+        String overallReview = (stats != null && stats.getOverallFeedback() != null)
+                ? stats.getOverallFeedback() : "";
 
         return new InterviewResultDetailResponse(
                 session.getId(),

--- a/src/main/java/com/aibe/team2/global/init/DataInitializer.java
+++ b/src/main/java/com/aibe/team2/global/init/DataInitializer.java
@@ -110,6 +110,7 @@ public class DataInitializer implements CommandLineRunner {
                        .jobRelevanceScore(random.nextDouble() * 100)
                        .logicalStructureScore(random.nextDouble() * 100)
                        .attitudeConfidenceScore(random.nextDouble() * 100)
+                       .overallFeedback("전반적으로 직무에 대한 이해도가 높고 답변이 논리적입니다. 다만, 구체적인 프로젝트 사례를 조금 더 덧붙이면 좋겠습니다.")
                        .speechHabits(habitDummy)
                        .build();
                setCreatedAt(stats, pastDate);

--- a/src/test/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepositoryCustomTest.java
+++ b/src/test/java/com/aibe/team2/domain/statistics/repository/InterviewResultStatisticsRepositoryCustomTest.java
@@ -1,0 +1,77 @@
+package com.aibe.team2.domain.statistics.repository;
+
+import com.aibe.team2.domain.mypage.entity.Member;
+import com.aibe.team2.domain.mypage.repository.MemberRepository;
+import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest(properties = {
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "GEMINI_API_KEY=dummy-key-for-test",
+        "GEMINI_API_URL=dummy-url"
+})
+@ActiveProfiles("local") // DataInitializer를 작동시켜 더미 데이터 생성을 위함
+@Transactional
+public class InterviewResultStatisticsRepositoryCustomTest {
+
+    @Autowired
+    private InterviewResultStatisticsRepository statisticsRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("QueryDSL : 회원 ID만 주어졌을 때(sessionType =null), 해당 해원의 모든 통계 데이터를 내림차순으로 조회한다.")
+    void findStatisticsByMemberIdOnly(){
+        // [Given] 더미 데이터 중 첫 번째 회원의 ID를 가져옴
+        Member firstMember = memberRepository.findAll().get(0);
+        Long memberId = firstMember.getId();
+
+        // [When] 세션 타입을 null로 넘겨서 동적 쿼리가 무시되는지 확인
+        List<InterviewResultStatistics> results = statisticsRepository.findStatisticsByCondition(memberId, null);
+
+        // [Then] 검증
+        assertFalse(results.isEmpty(), "더미 데이터가 조회되어야 합니다.");
+
+        // 정렬 검증(내림차순, 최신 데이터가 먼저 오는지)
+        if(results.size() > 1){
+            assertTrue(results.get(0).getCreatedAt().isAfter(results.get(1).getCreatedAt()) ||
+                    results.get(0).getCreatedAt().isEqual(results.get(1).getCreatedAt()));
+        }
+
+        log.info("전체 조회 테스트 성공! 조회된 개수: {}", results.size());
+    }
+
+    @Test
+    @DisplayName("QueryDSL: 회원 ID와 면접 타입(TEXT)가 주어졌을 때, 해당 조건에 맞는 데이터만 필터링하여 조회한다.")
+    void findStatisticsByMemberIdAndSessionType(){
+        // [Given] 더미 데이터 중 첫 번째 회원의 ID와 "TEXT" 타입 설정
+        Member firstMember = memberRepository.findAll().get(0);
+        Long memberId = firstMember.getId();
+        String targetType = "TEXT";
+
+        // [When] TEXT 타입 조건으로 조회
+        List<InterviewResultStatistics> results = statisticsRepository.findStatisticsByCondition(memberId, targetType);
+
+        // [Then] 검증
+        assertNotNull(results);
+        for(InterviewResultStatistics stat : results){
+            // 조인된 세션 테이블의 타입이 "TEXT"가 맞는지 100% 확신 검증
+            assertEquals(targetType, stat.getInterviewSession().getType(), "조회된 데이터 중 TEXT 타입이 아닌 것이 포함되어 있습니다.");
+        }
+
+        log.info("타입 필터링 조회 테스트 성공! 조회된 TEXT 면접 개수: {}", results.size());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closed: #47 

## 작업 내용
- QueryDSL 기반 동적 조회 구현 : `InterviewResultStatisticsRepositoryImpl`을 구현해 회원 ID 및 면접 유형에 따른 동적 통계 데이터 조회를 가능하게 함
- 하드코딩 제거 및 DB 연동 : Service 계층의 임시 데이터를 제거하고, 실제 DB에서 데이터를 추출해 DTO로 매핑하는 로직 구현
- 데이터 포맷팅 적용 : 프론트엔드 가독성을 위해 응답 데이터의 소수점 자릿수를 첫째/둘째 자리에서 반올림 처리하는 유틸 로직 추가
- 초기 데이터 구축 : `DataInitializer`을 보완해 서버 실행 시 면접 세션, 기록, 통계 더미 데이터가 자동으로 생성되도록 설정

<br/>

## 변경 사항 및 주의 사항
- QueryDSL 컴파일 : 필드 변경 시 `./gradlew clean compile.java`를 통해 Q클래스를 갱신해야 할 수 있습니다.
- API Key 에러 방지를 위해 Gemini에 기본 dummy 값을 설정해야 테스트 가능합니다.

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

##연관 이슈
- #35 
