### PR TITLE
[FEAT] 마이페이지 대시보드용 일일 통계 집계 배치 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ localstack/
 
 # IDE의 자체 빌더가 src/main/generated에 생성할 경우 대비
 /src/main/generated
+
+###Test 폴더 제외
+/src/test

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ localstack/
 /src/main/generated
 
 ###Test 폴더 제외
-/src/test
+/src/test/

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,13 @@ dependencies {
     
     implementation 'org.jsoup:jsoup:1.13.1'
 
+    // Spring Batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    // Spring Batch 테스트용 라이브러리 (추후 단위 테스트 작성 시 필요)
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.batch:spring-batch-test'
+
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     // Spring Batch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     // Spring Batch 테스트용 라이브러리 (추후 단위 테스트 작성 시 필요)
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
 
 

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
@@ -1,0 +1,12 @@
+package com.aibe.team2.domain.interview.repository;
+
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long> {
+
+    // 오늘 하루(Start~End)동안 생성된 면접 세션 개수 조회
+    long countByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/aibe/team2/domain/resume/repository/ResumeAnalysisRepository.java
+++ b/src/main/java/com/aibe/team2/domain/resume/repository/ResumeAnalysisRepository.java
@@ -2,8 +2,11 @@ package com.aibe.team2.domain.resume.repository;
 
 import com.aibe.team2.domain.resume.entity.ResumeAnalysisReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +14,12 @@ public interface ResumeAnalysisRepository extends JpaRepository<ResumeAnalysisRe
 
     // 특정 자기소개서의 최신 분석 결과 조회 (내림차순 정렬 후 첫 번째 데이터) // 마이페이지용
     Optional<ResumeAnalysisReport> findTopByResumeIdOrderByCreatedAtDesc(Long resumeId);
+
+    // 오늘 하루(Start~End)동안 생성된 자기소개서 개수 조회
+    @Query("SELECT COUNT(r) FROM ResumeAnalysisReport r WHERE r.resume.memberId = :memberId AND r.createdAt BETWEEN :start AND :end")
+    long countByMemberIdAndCreatedAtBetween(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/src/main/java/com/aibe/team2/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/aibe/team2/domain/resume/repository/ResumeRepository.java
@@ -4,6 +4,7 @@ import com.aibe.team2.domain.resume.entity.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +16,6 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
 
     // Id와 MemberId를 함께 검증하여 조회 (보안상 본인 자기소개서만 접근 가능하게 할 때 사용)
     Optional<Resume> findByIdAndMemberId(Long id, Long memberId);
+
+    long countByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime createdAtAfter, LocalDateTime createdAtBefore);
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/batch/StatisticsBatchConfig.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/batch/StatisticsBatchConfig.java
@@ -1,0 +1,135 @@
+package com.aibe.team2.domain.statistics.batch;
+
+import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
+import com.aibe.team2.domain.mypage.entity.Member;
+import com.aibe.team2.domain.mypage.repository.member.MemberRepository;
+import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
+import com.aibe.team2.domain.statistics.entity.DailyStatistics;
+import com.aibe.team2.domain.statistics.repository.DailyStatisticsRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.RepositoryItemWriter;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class StatisticsBatchConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final MemberRepository memberRepository;
+    private final ResumeAnalysisRepository resumeAnalysisRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final DailyStatisticsRepository dailyStatisticsRepository;
+
+    private static final int CHUNK_SIZE = 100;
+
+    // Job 설정(전체 배치 작업)
+    @Bean
+    public Job statisticsBatchJob() {
+        return new JobBuilder("statisticsBatchJob", jobRepository)
+                .start(dailyStatisticsStep())
+                .build();
+    }
+
+    // Step 설정(데이터 읽기 -> 가공 -> 쓰기 과정 정의)
+    @Bean
+    public Step dailyStatisticsStep() {
+        return new StepBuilder("dailyStatisticsStep", jobRepository)
+                .<Member, DailyStatistics> chunk(CHUNK_SIZE, transactionManager)
+                .reader(memberReader())
+                .processor(statisticsProcessor(null)) // null은 런타임에 JobParameter로 주입됨
+                .writer(statisticsWriter())
+                .build();
+    }
+
+    // ItemReader : Member 엔티티를 페이징 단위(Chunk)로 읽어옴
+    @Bean
+    @StepScope
+    public RepositoryItemReader<Member> memberReader() {
+        return new RepositoryItemReaderBuilder<Member>()
+                .name("memberReader")
+                .repository(memberRepository)
+                .methodName("findAll")
+                .pageSize(CHUNK_SIZE)
+                .sorts(Collections.singletonMap("memberId", Sort.Direction.ASC))
+                .build();
+    }
+
+    // ItemProcessor : Member 데이터를 받아 DailyStatistics로 변환
+    @Bean
+    @StepScope
+    public ItemProcessor<Member, DailyStatistics> statisticsProcessor(
+            @Value("#{jobParameters['targetDate']}") String targetDateStr
+    ) {
+        return member -> {
+            // 배치 실행 시 파라미터가 없으면 전날을 기준으로 삼음
+            LocalDate targetDate = (targetDateStr != null)
+                    ? LocalDate.parse(targetDateStr, DateTimeFormatter.ISO_DATE)
+                    : LocalDate.now().minusDays(1);
+
+            LocalDateTime startOfDay = targetDate.atStartOfDay();
+            LocalDateTime endOfDay = targetDate.atTime(LocalTime.MAX);
+
+            Long currentMemberId = member.getMemberId();
+
+            // 회원별 통계 조회 (00:00:00 ~ 23:59:59)
+            int resumeCount = (int) resumeAnalysisRepository.countByMemberIdAndCreatedAtBetween(currentMemberId, startOfDay, endOfDay);
+            int interviewCount = (int) interviewSessionRepository.countByMemberIdAndCreatedAtBetween(currentMemberId, startOfDay, endOfDay);
+
+            // 활동이 아예 없는 회원은 통계 테이블에 넣지 않음
+            if(resumeCount == 0 && interviewCount == 0){
+                return null;
+            }
+
+            // 멱등성 보장
+            DailyStatistics statistics = dailyStatisticsRepository.findByMemberIdAndStatsDate(currentMemberId, targetDate)
+                    .orElseGet(() -> DailyStatistics.builder()
+                            .member(member)
+                            .statsDate(targetDate)
+                            .totalResumeCount(0) // 초기값 0
+                            .totalInterviewCount(0) // 초기값 0
+                            .build());
+
+            // 조회된 건수를 객체에 업데이트
+            statistics.updateCounts(resumeCount, interviewCount);
+
+            return statistics;
+        };
+    }
+
+    // ItemWriter : 완성된 통계 데이터를 DB에 저장
+    @Bean
+    @StepScope
+    public RepositoryItemWriter<DailyStatistics> statisticsWriter() {
+        return new RepositoryItemWriterBuilder<DailyStatistics>()
+                .repository(dailyStatisticsRepository)
+                .methodName("save")
+                .build();
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/batch/StatisticsBatchScheduler.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/batch/StatisticsBatchScheduler.java
@@ -1,0 +1,40 @@
+package com.aibe.team2.domain.statistics.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StatisticsBatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job dailyStatisticsJob;
+
+    // 매일 00시 30분에 실행(Cron 표현식) - 초 분 시 일 월 요일
+    @Scheduled(cron = "0 30 0 * * *")
+    public void runDailyStatisticsJob() {
+        // 배치 실행의 고유성을 위한 파라미터(어제 날짜 기준)
+        String targetDate = LocalDate.now().minusDays(1).toString();
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("targetDate", targetDate)
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        try{
+            log.info("일별 통계 집계 배치 실행 시작 - 대상 일자: {}", targetDate);
+            jobLauncher.run(dailyStatisticsJob, jobParameters);
+            log.info("일별 통계 집계 배치 실행 완료");
+        } catch (Exception e) {
+            log.error("일별 통계 집계 배치 실행 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/DailyStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/DailyStatisticsController.java
@@ -1,0 +1,34 @@
+package com.aibe.team2.domain.statistics.controller;
+
+import com.aibe.team2.domain.statistics.dto.DailyStatisticsResponse;
+import com.aibe.team2.domain.statistics.service.DailyStatisticsService;
+import com.aibe.team2.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/mypage/statistics")
+@RequiredArgsConstructor
+public class DailyStatisticsController {
+
+    private final DailyStatisticsService dailyStatisticsService;
+
+    // [FR-STA-02] 일 단위 통계 집계 API
+    // GET /api/v1/mypage/statistics?targetDate=2026-02-26
+    @GetMapping
+    public ResponseEntity<ApiResponse<DailyStatisticsResponse>> getDailyStatistics(
+            // TODO : Spring Security 적용 후 주석 해제 및 Mock-Member-Id 제거
+            // @AuthenticationPrincipal UserDetails userDetails,
+
+            // [임시] Security 구현 전 테스트를 위해 Header로 memberId를 받음
+            @RequestHeader(value = "Mock-Member-Id", defaultValue = "1") Long memberId,
+            @RequestParam(value = "targetDate", required = false) String targetDate
+    ){
+        // [임시] Security 구현 후 복구
+        // Long memberId = Long.parseLong(userDetails.getUsername());
+        DailyStatisticsResponse result = dailyStatisticsService.getDailyStatistics(memberId, targetDate);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/DailyStatisticsResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/DailyStatisticsResponse.java
@@ -1,0 +1,26 @@
+package com.aibe.team2.domain.statistics.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class DailyStatisticsResponse {
+    private String targetDate; // 집계 기준 일자
+    private int resumeReviewCount; // 자기소개서 첨삭 건수
+    private int completedInterviewCount; // 모의 면접 완료 건수
+    private double averageInterviewScore; // 모의 면접 평균 점수(추가 계산 필요 시 사용)
+    private int totalAiUsageMinutes; // 총 AI 사용 시간
+
+    public static DailyStatisticsResponse of(LocalDate date, int resumeCount, int interviewCount){
+        return DailyStatisticsResponse.builder()
+                .targetDate(date.toString())
+                .resumeReviewCount(resumeCount)
+                .completedInterviewCount(interviewCount)
+                .averageInterviewScore(0.0)
+                .totalAiUsageMinutes(0)
+                .build();
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/entity/DailyStatistics.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/entity/DailyStatistics.java
@@ -1,0 +1,52 @@
+package com.aibe.team2.domain.statistics.entity;
+
+import com.aibe.team2.domain.mypage.entity.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "daily_statistics",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_daily_statistics_member_date",
+                        columnNames = {"member_id", "stats_date"}
+                )
+        })
+public class DailyStatistics {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Member 엔티티와 연관관계 매핑
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "stats_date", nullable = false)
+    private LocalDate statsDate;
+
+    @Column(name = "total_resume_count", nullable = false)
+    private int totalResumeCount;
+
+    @Column(name = "total_interview_count", nullable = false)
+    private int totalInterviewCount;
+
+    @Builder
+    public DailyStatistics(Member member, LocalDate statsDate, int totalResumeCount, int totalInterviewCount) {
+        this.member = member;
+        this.statsDate = statsDate;
+        this.totalResumeCount = totalResumeCount;
+        this.totalInterviewCount = totalInterviewCount;
+    }
+
+    public void updateCounts(int resumeCount, int interviewCount) {
+        this.totalResumeCount = resumeCount;
+        this.totalInterviewCount = interviewCount;
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/DailyStatisticsRepository.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/DailyStatisticsRepository.java
@@ -1,0 +1,38 @@
+package com.aibe.team2.domain.statistics.repository;
+
+import com.aibe.team2.domain.statistics.entity.DailyStatistics;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyStatisticsRepository extends JpaRepository<DailyStatistics, Long> {
+
+    // 특정 회원의 특정 기간 통계 조회(대시보드 그래프용)
+    @Query("""
+          select ds
+          from DailyStatistics ds
+          where ds.member.memberId = :memberId
+            and ds.statsDate between :start and :end
+    """)
+    List<DailyStatistics> findAllByMemberAndStatsDateBetween(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDate start,
+            @Param("end") LocalDate end
+    );
+
+    // 특정 회원의 특정 날짜 통계 조회(중복 확인용 or 단건 조회용)
+    @Query("""
+      select ds
+      from DailyStatistics ds
+      where ds.member.memberId = :memberId
+        and ds.statsDate = :statsDate
+""")
+    Optional<DailyStatistics> findByMemberIdAndStatsDate(
+            @Param("memberId") Long memberId,
+            @Param("statsDate") LocalDate statsDate
+    );
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/service/DailyStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/DailyStatisticsService.java
@@ -49,9 +49,9 @@ public class DailyStatisticsService {
         ValueOperations<String, Object> operations = redisTemplate.opsForValue();
 
         // 3. Cache Hit : Redis에 데이터가 있는지 확인
-        if(Boolean.TRUE.equals(redisTemplate.hasKey(redisKey))) {
-            log.info("Cache Hit! Key: {}", redisKey);
-            return (DailyStatisticsResponse) operations.get(redisKey);
+        DailyStatisticsResponse cachedResponse = (DailyStatisticsResponse) operations.get(redisKey);
+        if(cachedResponse != null){
+            return cachedResponse;
         }
 
         // 4. Cache Miss : DB에서 데이터 집계

--- a/src/main/java/com/aibe/team2/domain/statistics/service/DailyStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/DailyStatisticsService.java
@@ -1,0 +1,81 @@
+package com.aibe.team2.domain.statistics.service;
+
+import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
+import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
+import com.aibe.team2.domain.statistics.dto.DailyStatisticsResponse;
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DailyStatisticsService {
+
+    private final ResumeAnalysisRepository resumeAnalysisRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 일 단위 통계 조회
+    public DailyStatisticsResponse getDailyStatistics(Long memberId, String targetDateStr) {
+
+        LocalDate targetDate;
+
+        // 1. 날짜 파싱 및 예외 전환
+        try{
+            targetDate = (targetDateStr == null)
+                    ? LocalDate.now()
+                    : LocalDate.parse(targetDateStr, DateTimeFormatter.ISO_DATE);
+        } catch (DateTimeParseException e) {
+            log.warn("잘못된 날짜 형식 요청: {}", targetDateStr);
+            throw new BusinessException(ErrorCode.COMMON_408);
+        }
+
+        // 2. Redis Key 생성
+        String redisKey = "status:user:" + memberId + ":" + targetDate.toString();
+        ValueOperations<String, Object> operations = redisTemplate.opsForValue();
+
+        // 3. Cache Hit : Redis에 데이터가 있는지 확인
+        if(Boolean.TRUE.equals(redisTemplate.hasKey(redisKey))) {
+            log.info("Cache Hit! Key: {}", redisKey);
+            return (DailyStatisticsResponse) operations.get(redisKey);
+        }
+
+        // 4. Cache Miss : DB에서 데이터 집계
+        log.info("Cache Miss 발생! DB 집계 시작! 키: {}", redisKey);
+        DailyStatisticsResponse statsDto = aggregateFromDb(memberId, targetDate);
+
+        // 5. Redis에 저장(TTL 설정 : 자정까지)
+        operations.set(redisKey, statsDto, Duration.ofDays(1));
+
+        return statsDto;
+    }
+
+    // DB 집계 로직 분리
+    private DailyStatisticsResponse aggregateFromDb(Long memberId, LocalDate date) {
+        LocalDateTime startOfDay = date.atStartOfDay();
+        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
+
+        // 첨삭 건수
+        int resumeCount = (int) resumeAnalysisRepository.countByMemberIdAndCreatedAtBetween(memberId, startOfDay, endOfDay);
+
+        // 면접 건수
+        int interviewCount = (int) interviewSessionRepository.countByMemberIdAndCreatedAtBetween(memberId, startOfDay, endOfDay);
+
+        // DTO 생성 및 반환
+        return DailyStatisticsResponse.of(date, resumeCount, interviewCount);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closed: #57 

## 작업 내용
- 통계 엔티티 설계 및 생성 : 필드 구성과 함께 데이터 중복 방지를 위한 유티크 제약 조건 설정
- 스프링 배치 잡 설정 : Reader(전체 회원 대상 페이징 및 청크 단위 조회)/Processor(전일 기준 면접 세션 및 자기소개서 분석 건수 집계)/Writer(DailyStatistics) 테이블에 통계 결과 적재
- 배치 스케줄러 구현 : 매일 00시 30분에 실행되도록 크론 표현식 적용
- 단위 테스트 작성 및 보완

<br/>

## 변경 사항 및 주의 사항
- 데이터 정합성 : 실제 스케줄러 실행 시간과 데이터 집계 대상 시간을 분리. 이를 통해 23시 59분에 발생한 트랜잭션이 지연되더라도 누락 없이 안전하게 포함되도록 버퍼를 둠
- 데이터 무결성 및 멱등성 : 배치가 모종의 이유로 중복 실행되더라도 통계가 중복 적재되지 않도록, 엔티티 유니크 제약 조건과 함께 조회 후 삽입 및 수정하는 로직을 적용해 멱등성 보장
- 성능 최적화] : 전 회원을 대상으로 하는 대용량 데이터 조회이므로, 메모리 부하 분산을 위해 `Chunk` 단위 트랜잭션 처리를 필수로 적용
- 정책 상수화 고려 : 현재 서비스 정책상 1일 제한(첨삭 3회, 면접 2회)이 있으나, 추후 정책 변동 가능성을 고려하여 해당 제한 횟수는 하드코딩하지 않고 상수로 관리하도록 구현
- 협업 참고 : `.gitignore` 룰에 따라 테스트 디렉토리(`src/test`)도 함께 푸시. 다른 팀원들도 테스트 환경 구동 시 `RedisTemplate` 등의 Mock 빈 주입이 올바르게 되어 있는지 참고
<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
