### PR TITLE
[FEAT] 마이페이지 성장 지표 통계 API 및 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/aibe/team2/domain/statistics/controller/GrowthStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/GrowthStatisticsController.java
@@ -1,0 +1,33 @@
+package com.aibe.team2.domain.statistics.controller;
+
+import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
+import com.aibe.team2.domain.statistics.service.GrowthStatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class GrowthStatisticsController {
+
+    private final GrowthStatisticsService growthStatisticsService;
+
+    @GetMapping("/statistics/growth")
+    public ResponseEntity<List<GrowthResultResponse>>getGrowthStatistics(
+            // TODO : Spring Security 구현 후 수정
+            // @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+
+        // [변경 예정]
+        // Long currentMemberId = userDetails.getMemberId();
+        Long currentMemberId = 1L;
+        List<GrowthResultResponse> response = growthStatisticsService.getGrowthStatistics(currentMemberId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/GrowthResultResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/GrowthResultResponse.java
@@ -1,0 +1,17 @@
+package com.aibe.team2.domain.statistics.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class GrowthResultResponse {
+    private String metricName;
+    private BigDecimal previousValue;
+    private BigDecimal currentValue;
+    private BigDecimal difference;
+    private BigDecimal growthRate;
+    private String displayGrowthRate; // "신규 진입" 등의 예외 문자열 처리를 위해 추가
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/interview/InterviewResultStatisticsRepositoryCustom.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/interview/InterviewResultStatisticsRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.aibe.team2.domain.statistics.repository.interview;
 
 import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import com.querydsl.core.Tuple;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface InterviewResultStatisticsRepositoryCustom {
 
-    // 특정 회원의 통계 결화를 조회하며, 면접 타입(TEXT/VOICE)에 따라 동적 필터링을 수행
+    // 1. 특정 회원의 통계 결과를 조회하며, 면접 타입(TEXT/VOICE)에 따라 동적 필터링을 수행
     List<InterviewResultStatistics> findStatisticsByCondition(Long memberId, String sessionType);
+
+    // 2. [추가된 튜플 메서드] 특정 기간 동안의 6개 지표 평균 계산
+    Tuple findAverageMetricsTupleByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/interview/InterviewResultStatisticsRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/interview/InterviewResultStatisticsRepositoryImpl.java
@@ -1,12 +1,14 @@
 package com.aibe.team2.domain.statistics.repository.interview;
 
 import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.aibe.team2.domain.interview.entity.QInterviewSession.interviewSession;
@@ -33,6 +35,26 @@ public class InterviewResultStatisticsRepositoryImpl implements InterviewResultS
                 .fetch();
     }
 
+    @Override
+    public Tuple findAverageMetricsTupleByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end) {
+        return queryFactory
+                .select(
+                        interviewResultStatistics.avgClarity.avg(),
+                        interviewResultStatistics.avgPersuasiveness.avg(),
+                        interviewResultStatistics.avgConsistency.avg(),
+                        interviewResultStatistics.jobRelevanceScore.avg(),
+                        interviewResultStatistics.logicalStructureScore.avg(),
+                        interviewResultStatistics.attitudeConfidenceScore.avg()
+                )
+                .from(interviewResultStatistics)
+                .join(interviewResultStatistics.interviewSession, interviewSession)
+                .where(
+                        memberIdEq(memberId), // 기존에 만들어둔 재사용 가능한 조건 메서드 활용
+                        createdAtBetween(start, end) // 기간 필터링 조건 메서드 호출
+                )
+                .fetchOne();
+    }
+
     // 동적 쿼리를 위한 BooleanExpression 메서드
     // 1. 회원 ID 일치 여부(필수 조건)
     private BooleanExpression memberIdEq(Long memberId) {
@@ -46,5 +68,13 @@ public class InterviewResultStatisticsRepositoryImpl implements InterviewResultS
     private BooleanExpression sessionTypeEq(String sessionType) {
 
         return StringUtils.hasText(sessionType) ? interviewSession.interviewType.eq(sessionType) : null;
+    }
+
+    // 3. 생성일자 기간 필터링 조건
+    private BooleanExpression createdAtBetween(LocalDateTime start, LocalDateTime end) {
+        if(start == null || end == null) {
+            return null;
+        }
+        return interviewResultStatistics.createdAt.between(start, end);
     }
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/service/GrowthStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/GrowthStatisticsService.java
@@ -1,0 +1,113 @@
+package com.aibe.team2.domain.statistics.service;
+
+import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
+import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
+import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
+import com.aibe.team2.domain.statistics.repository.interview.InterviewResultStatisticsRepository;
+import com.aibe.team2.domain.statistics.util.GrowthCalculator;
+import com.querydsl.core.Tuple;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.aibe.team2.domain.statistics.entity.QInterviewResultStatistics.interviewResultStatistics;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GrowthStatisticsService {
+
+    private final ResumeAnalysisRepository resumeAnalysisRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewResultStatisticsRepository interviewResultStatisticsRepository;
+
+    public List<GrowthResultResponse> getGrowthStatistics(Long memberId) {
+        List<GrowthResultResponse> growthResults = new ArrayList<>();
+
+        // 1. 기간 설정 - 이번 달과 지난달의 시작/종료 시간 계산
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime currentMonthStart = YearMonth.now().atDay(1).atStartOfDay();
+        LocalDateTime previousMonthStart = YearMonth.now().minusMonths(1).atDay(1).atStartOfDay();
+        LocalDateTime previousMonthEnd = currentMonthStart.minusNanos(1);
+
+        // 2. 이력서 수정 횟수 집계 - 제공된 쿼리 메서드 활용
+        long currResumeEdits = resumeAnalysisRepository.countByMemberIdAndCreatedAtBetween(
+                memberId, currentMonthStart, now);
+        long prevResumeEdits = resumeAnalysisRepository.countByMemberIdAndCreatedAtBetween(
+                memberId, previousMonthStart, previousMonthEnd);
+        growthResults.add(GrowthCalculator.calculateGrowth(
+                "이력서 수정 횟수",
+                BigDecimal.valueOf(prevResumeEdits),
+                BigDecimal.valueOf(currResumeEdits)
+        ));
+
+        // 3. 모의 면접 횟수 집계
+        long currInterviews = interviewSessionRepository.countByMemberIdAndCreatedAtBetween(
+                memberId, currentMonthStart, now);
+        long prevInterviews = interviewSessionRepository.countByMemberIdAndCreatedAtBetween(
+                memberId, previousMonthStart, previousMonthEnd);
+
+        growthResults.add(GrowthCalculator.calculateGrowth(
+                "모의 면접 횟수",
+                BigDecimal.valueOf(prevInterviews),
+                BigDecimal.valueOf(currInterviews)
+        ));
+
+        // 4. 답변 정확도 평균 집계
+        Tuple currTuple = interviewResultStatisticsRepository.findAverageMetricsTupleByMemberIdAndCreatedAtBetween(
+                memberId, currentMonthStart, now);
+        Tuple prevTuple = interviewResultStatisticsRepository.findAverageMetricsTupleByMemberIdAndCreatedAtBetween(
+                memberId, previousMonthStart, previousMonthEnd);
+
+        // 명확성 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("명확성 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.avgClarity.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.avgClarity.avg())));
+
+        // 설득력 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("설득력 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.avgPersuasiveness.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.avgPersuasiveness.avg())));
+
+        // 일관성 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("일관성 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.avgConsistency.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.avgConsistency.avg())));
+
+        // 직무 적합성 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("직무 적합성 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.jobRelevanceScore.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.jobRelevanceScore.avg())));
+
+        // 논리적 구조 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("논리적 구조 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.logicalStructureScore.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.logicalStructureScore.avg())));
+
+        // 태도 및 자신감 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("태도 및 자신감 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.attitudeConfidenceScore.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.attitudeConfidenceScore.avg())));
+
+        return growthResults;
+    }
+
+    // 튜플 전용 헬퍼 메서드
+    private BigDecimal getSafeScore(Tuple tuple, com.querydsl.core.types.dsl.NumberExpression<Double> expression) {
+        if (tuple == null || tuple.get(expression) == null) {
+            // 값이 아예 없을 때도 "0.00"으로 포맷을 예쁘게 맞춰줍니다.
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        // DB에서 꺼낸 Double 값을 BigDecimal로 바꾼 직후, 바로 소수점 둘째 자리에서 반올림!
+        return BigDecimal.valueOf(tuple.get(expression))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/util/GrowthCalculator.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/util/GrowthCalculator.java
@@ -1,0 +1,57 @@
+package com.aibe.team2.domain.statistics.util;
+
+import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class GrowthCalculator {
+
+    // 인스턴스화 방지
+    private GrowthCalculator() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    // 성장률 계산 및 DTO 반환 메서드
+    public static GrowthResultResponse calculateGrowth(String metricName, BigDecimal previous, BigDecimal current) {
+
+        // null 방어
+        if(previous == null || current == null) {
+            throw new IllegalArgumentException("previous/current는 null일 수 없습니다.");
+        }
+
+        // 소수점 둘째 자리 반올림
+        BigDecimal roundedPrevious = previous.setScale(2, RoundingMode.HALF_UP);
+        BigDecimal roundedCurrent = current.setScale(2, RoundingMode.HALF_UP);
+
+        // 변화량 계산
+        BigDecimal difference = current.subtract(previous);
+
+        // 0으로 나누기 방지 및 신규 사용자 처리 로직
+        if(previous.compareTo(BigDecimal.ZERO) == 0) {
+            return GrowthResultResponse.builder()
+                    .metricName(metricName)
+                    .previousValue(previous)
+                    .currentValue(current)
+                    .difference(difference)
+                    .growthRate(null) // 이전 값이 0이면 성장률 수치로 정의할 수 없음
+                    .displayGrowthRate("신규 진입")
+                    .build();
+        }
+
+        // 성장률 계산 : (Difference / Previous) * 100
+        // 소수점 셋째 자리에서 반올림하여 둘째 자리까지 표현
+        BigDecimal growthRate = difference.divide(previous, 4, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return GrowthResultResponse.builder()
+                .metricName(metricName)
+                .previousValue(roundedPrevious)
+                .currentValue(roundedCurrent)
+                .difference(difference)
+                .growthRate(growthRate)
+                .displayGrowthRate(growthRate.toString() + "%")
+                .build();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closed: #60 

## 작업 내용
- `[FR-REP-03] 성장 지표 통계` GET `/api/v1/mypage/statistics/growth` 엔드포인트 구현
- `GrowthStatisticsService` 구현 (이력서 수정, 모의 면접, 세부 6개 지표 성장률 취합 로직)
- QueryDSL `Tuple`을 활용하여 6가지 면접 세부 지표의 평균을 한 번의 쿼리로 조회하도록 최적화 (`findAverageMetricsTupleByMemberIdAndCreatedAtBetween`)
- `GrowthCalculator` 구현 및 예외/엣지 케이스 처리 (신규 진입자 분모 0 처리, `BigDecimal` 소수점 둘째 자리 반올림 적용)
- `GrowthCalculatorTest` (순수 계산 로직 검증) 및 `GrowthStatisticsServiceTest` (Mockito 활용 서비스 흐름 검증) 작성 완료
<br/>

## 변경 사항 및 주의 사항
- 소수점 처리: 모든 성장률 및 점수는 `BigDecimal`의 `RoundingMode.HALF_UP`을 사용하여 소수점 둘째 자리에서 깔끔하게 반올림되도록 처리했습니다. 프론트엔드에서는 전달받은 데이터를 그대로 표출하시면 됩니다.
- QueryDSL 튜플 사용: DTO 클래스 증가를 막기 위해 레포지토리에서 6개 평균값을 DTO 대신 `Tuple` 객체로 반환하도록 작업했습니다.
- Spring Security (TODO): `GrowthStatisticsController` 내에 현재 유저 ID를 가져오는 부분은 `Long currentMemberId = 1L;`로 하드코딩 되어 있습니다. 추후 Security 적용 시 `@AuthenticationPrincipal`로 교체해야 합니다.
<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
