### PR TITLE
[FEAT] 마이페이지 모의 면접 이력 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
 
-public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long> {
+public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long>, InterviewSessionRepositoryCustom {
 
     // 오늘 하루(Start~End)동안 생성된 면접 세션 개수 조회
     long countByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryCustom.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.aibe.team2.domain.interview.repository;
 
-import com.aibe.team2.domain.mypage.dto.InterviewSessionListResponse;
+import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryCustom.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.aibe.team2.domain.interview.repository;
+
+import com.aibe.team2.domain.mypage.dto.InterviewSessionListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface InterviewSessionRepositoryCustom {
+    Page<InterviewSessionListResponse> findInterviewSessionList(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.aibe.team2.domain.interview.repository;
+
+import com.aibe.team2.domain.mypage.dto.InterviewSessionListResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.aibe.team2.domain.interview.entity.QInterviewSession.interviewSession;
+import static com.aibe.team2.domain.jobposting.entity.QJobPosting.jobPosting;
+import static com.aibe.team2.domain.resume.entity.QResume.resume;
+
+@RequiredArgsConstructor
+public class InterviewSessionRepositoryImpl implements InterviewSessionRepositoryCustom {
+
+    private final JPAQueryFactory  queryFactory;
+
+    @Override
+    public Page<InterviewSessionListResponse> findInterviewSessionList(Long memberId, Pageable pageable) {
+
+        // 1. 실제 데이터 조회 쿼리
+        List<InterviewSessionListResponse> content = queryFactory
+                .select(Projections.constructor(InterviewSessionListResponse.class,
+                        interviewSession.id,
+                        resume.title,
+                        jobPosting.companyName,
+                        jobPosting.jobTitle,
+                        interviewSession.interviewMode,
+                        interviewSession.interviewType,
+                        interviewSession.status,
+                        interviewSession.finalScore,
+                        interviewSession.createdAt
+                ))
+                .from(interviewSession)
+                // [핵심] 엔티티에 연관관계가 없으므로 ON 절로 ID 값을 직접 매칭
+                .leftJoin(resume).on(interviewSession.resumeId.eq(resume.id))
+                .leftJoin(jobPosting).on(interviewSession.jobPostingId.eq(jobPosting.id))
+                .where(interviewSession.memberId.eq(memberId))
+                .orderBy(interviewSession.createdAt.desc()) // 최신순 정렬
+                .offset(pageable.getOffset())               // 페이징 시작점
+                .limit(pageable.getPageSize())              // 페이지 크기
+                .fetch();
+
+        // 2. 전체 개수 조회 쿼리
+        JPAQuery<Long> countQuery = queryFactory
+                .select(interviewSession.count())
+                .from(interviewSession)
+                .where(interviewSession.memberId.eq(memberId));
+
+        // 3. 데이터와 카운트 쿼리를 조합하여 Page 객체로 반환
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.aibe.team2.domain.interview.repository;
 
-import com.aibe.team2.domain.mypage.dto.InterviewSessionListResponse;
+import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
@@ -1,0 +1,34 @@
+package com.aibe.team2.domain.mypage.controller;
+
+import com.aibe.team2.domain.mypage.dto.InterviewSessionListResponse;
+import com.aibe.team2.domain.mypage.service.MypageInterviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage/interviews")
+public class MypageInterviewController {
+
+    private final MypageInterviewService mypageInterviewService;
+
+    @GetMapping
+    public ResponseEntity<Page<InterviewSessionListResponse>> getInterviewSessionList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        // TODO : Spring Security 연동 후 하드코딩 제거
+        Long currentUserId = 1L;
+        Pageable pageRequest = PageRequest.of(page, size);
+        Page<InterviewSessionListResponse> response = mypageInterviewService.getInterviewSessionList(currentUserId, pageRequest);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
@@ -1,6 +1,6 @@
 package com.aibe.team2.domain.mypage.controller;
 
-import com.aibe.team2.domain.mypage.dto.InterviewSessionListResponse;
+import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import com.aibe.team2.domain.mypage.service.MypageInterviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/InterviewSessionListResponse.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/InterviewSessionListResponse.java
@@ -1,0 +1,22 @@
+package com.aibe.team2.domain.mypage.dto;
+
+import com.aibe.team2.domain.interview.entity.InterviewSessionStatus;
+import java.time.LocalDateTime;
+
+public record InterviewSessionListResponse(
+        Long sessionId,
+        String resumeTitle,     // QueryDSL이 가져올 자소서 제목
+        String companyName,     // QueryDSL이 가져올 회사명
+        String jobTitle,        // QueryDSL이 가져올 직무명
+        String interviewMode,
+        String interviewType,
+        InterviewSessionStatus status,
+        Integer finalScore,
+        LocalDateTime createdAt
+) {
+    public InterviewSessionListResponse {
+        resumeTitle = (resumeTitle != null) ? resumeTitle : "선택된 자소서 없음";
+        companyName = (companyName != null) ? companyName : "자유 면접";
+        jobTitle = (jobTitle != null) ? jobTitle : "-";
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/response/InterviewSessionListResponse.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/response/InterviewSessionListResponse.java
@@ -1,4 +1,4 @@
-package com.aibe.team2.domain.mypage.dto;
+package com.aibe.team2.domain.mypage.dto.response;
 
 import com.aibe.team2.domain.interview.entity.InterviewSessionStatus;
 import java.time.LocalDateTime;
@@ -14,9 +14,13 @@ public record InterviewSessionListResponse(
         Integer finalScore,
         LocalDateTime createdAt
 ) {
+    // 상수 추출
+    private static final String NO_RESUME_SELECTED = "선택된 자기소개서 없음";
+    private static final String FREESTYLE_INTERVIEW = "자유 면접";
+    private static final String NO_JOB_TITLE = "-";
     public InterviewSessionListResponse {
-        resumeTitle = (resumeTitle != null) ? resumeTitle : "선택된 자소서 없음";
-        companyName = (companyName != null) ? companyName : "자유 면접";
-        jobTitle = (jobTitle != null) ? jobTitle : "-";
+        resumeTitle = (resumeTitle != null) ? resumeTitle : NO_RESUME_SELECTED;
+        companyName = (companyName != null) ? companyName : FREESTYLE_INTERVIEW;
+        jobTitle = (jobTitle != null) ? jobTitle : NO_JOB_TITLE;
     }
 }

--- a/src/main/java/com/aibe/team2/domain/mypage/service/MypageInterviewService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/MypageInterviewService.java
@@ -1,0 +1,22 @@
+package com.aibe.team2.domain.mypage.service;
+
+import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
+import com.aibe.team2.domain.mypage.dto.InterviewSessionListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MypageInterviewService {
+
+    private final InterviewSessionRepository interviewSessionRepository;
+
+    public Page<InterviewSessionListResponse> getInterviewSessionList(Long memberId, Pageable pageable) {
+
+        return interviewSessionRepository.findInterviewSessionList(memberId, pageable);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/service/MypageInterviewService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/MypageInterviewService.java
@@ -1,7 +1,7 @@
 package com.aibe.team2.domain.mypage.service;
 
 import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
-import com.aibe.team2.domain.mypage.dto.InterviewSessionListResponse;
+import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/aibe/team2/domain/resume/repository/ResumeAnalysisRepository.java
+++ b/src/main/java/com/aibe/team2/domain/resume/repository/ResumeAnalysisRepository.java
@@ -1,6 +1,8 @@
 package com.aibe.team2.domain.resume.repository;
 
 import com.aibe.team2.domain.resume.entity.ResumeAnalysisReport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,4 +24,11 @@ public interface ResumeAnalysisRepository extends JpaRepository<ResumeAnalysisRe
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    @Query(value = "SELECT r FROM ResumeAnalysisReport r " +
+            "JOIN FETCH r.resume res " +
+            "JOIN FETCH r.jobPosting jp " +
+            "WHERE res.memberId = :memberId",
+            countQuery = "SELECT count(r) FROM ResumeAnalysisReport r WHERE r.resume.memberId = :memberId")
+    Page<ResumeAnalysisReport> findByMemberIdWithDetails(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/GrowthStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/GrowthStatisticsController.java
@@ -1,0 +1,33 @@
+package com.aibe.team2.domain.statistics.controller;
+
+import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
+import com.aibe.team2.domain.statistics.service.GrowthStatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class GrowthStatisticsController {
+
+    private final GrowthStatisticsService growthStatisticsService;
+
+    @GetMapping("/statistics/growth")
+    public ResponseEntity<List<GrowthResultResponse>>getGrowthStatistics(
+            // TODO : Spring Security 구현 후 수정
+            // @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+
+        // [변경 예정]
+        // Long currentMemberId = userDetails.getMemberId();
+        Long currentMemberId = 1L;
+        List<GrowthResultResponse> response = growthStatisticsService.getGrowthStatistics(currentMemberId);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
@@ -1,6 +1,5 @@
 package com.aibe.team2.domain.statistics.controller;
 
-import com.aibe.team2.domain.statistics.dto.common.RadarChartStatResponse;
 import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse;
 import com.aibe.team2.domain.statistics.service.InterviewStatisticsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,8 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Slf4j
 @Tag(name = "통계/이력 API", description = "면접 결과 통계 및 이력 조회 관련 API")
@@ -21,22 +18,22 @@ public class InterviewStatisticsController {
 
     private final InterviewStatisticsService interviewStatisticsService;
 
-    // [FR-REP-04] 면접 이력 - 목록 조회(다건)
-    // 쿼리 파라미터로 sessionType 필터링
-    @Operation(summary = "내 면접 이력 목록 조회", description = "사용자의 전체 면접 이력과 통계 요약 정보를 리스트로 조회합니다.")
-    @GetMapping
-    public ResponseEntity<List<RadarChartStatResponse>> getInterviewList(
-            @RequestParam(required = false) String sessionType
-            // TODO : Spring Security 연동
-            // @AuthenticationPrincipal CustomUserDetails userDetails
-    ){
-        // TODO : Spring Security 연동
-        // Long currentUserId = userDetails.getId();
-        Long currentUserId = 1L;
-        List<RadarChartStatResponse> response = interviewStatisticsService.getInterviewStatisticsList(currentUserId, sessionType);
-
-        return ResponseEntity.ok(response);
-    }
+    // // [FR-REP-04] 면접 이력 - 목록 조회(다건)
+    // // 쿼리 파라미터로 sessionType 필터링
+    // @Operation(summary = "내 면접 이력 목록 조회", description = "사용자의 전체 면접 이력과 통계 요약 정보를 리스트로 조회합니다.")
+    // @GetMapping
+    // public ResponseEntity<List<RadarChartStatResponse>> getInterviewList(
+    //         @RequestParam(required = false) String sessionType
+    //         // TODO : Spring Security 연동
+    //         // @AuthenticationPrincipal CustomUserDetails userDetails
+    // ){
+    //     // TODO : Spring Security 연동
+    //     // Long currentUserId = userDetails.getId();
+    //     Long currentUserId = 1L;
+    //     List<RadarChartStatResponse> response = interviewStatisticsService.getInterviewStatisticsList(currentUserId, sessionType);
+    //
+    //     return ResponseEntity.ok(response);
+    // }
 
     // [FR-REP-04] 면접 이력 - 상세 조회(리포트)
     @Operation(summary = "면접 상세 결과 조회", description = "특정 면접 세션의 상세 대화 내용, 평가 점수, 피드백 등을 조회합니다. ")

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/ResumeStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/ResumeStatisticsController.java
@@ -1,14 +1,15 @@
 package com.aibe.team2.domain.statistics.controller;
 
+import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisListResponse;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse;
 import com.aibe.team2.domain.statistics.service.ResumeStatisticsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -17,6 +18,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class ResumeStatisticsController {
 
     private final ResumeStatisticsService resumeStatisticsService;
+
+    // [FR-REP-04] 자기소개서 첨삭 이력 조회
+    @GetMapping("/analysis")
+    public ResponseEntity<Page<ResumeAnalysisListResponse>> getResumeAnalysisList(
+            @RequestParam(defaultValue = "0") int page, // URL 파라미터: 시작 페이지 (기본 0)
+            @RequestParam(defaultValue = "10") int size // URL 파라미터: 페이지당 개수 (기본 10개)
+    ) {
+        // TODO : Spring Security 연동 시 수정
+        Long currentUserId = 1L;
+        // 최신순으로 정렬하는 페이징 객체 생성
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<ResumeAnalysisListResponse> response = resumeStatisticsService.getResumeAnalysisList(currentUserId, pageRequest);
+
+        return ResponseEntity.ok(response);
+    }
 
     // [FR-REP-04] 자기소개서 첨삭 이력 - 상세 조회(리포트)
     @GetMapping("/analysis/{analysisId}")

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/GrowthResultResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/GrowthResultResponse.java
@@ -1,0 +1,17 @@
+package com.aibe.team2.domain.statistics.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class GrowthResultResponse {
+    private String metricName;
+    private BigDecimal previousValue;
+    private BigDecimal currentValue;
+    private BigDecimal difference;
+    private BigDecimal growthRate;
+    private String displayGrowthRate; // "신규 진입" 등의 예외 문자열 처리를 위해 추가
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/resume/ResumeAnalysisListResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/resume/ResumeAnalysisListResponse.java
@@ -1,0 +1,27 @@
+package com.aibe.team2.domain.statistics.dto.resume;
+
+import com.aibe.team2.domain.resume.entity.ResumeAnalysisReport;
+
+import java.time.LocalDateTime;
+
+public record ResumeAnalysisListResponse(
+        Long analysisId, // 클릭 시 상세 조회(리포트)로 넘어가기 위한 키값
+        String resumeTitle, // 자기소개서 제목
+        String companyName, // 지원 회사명
+        String jobTitle, // 지원 직무명
+        Integer matchScore, // 매칭 점수
+        String status, // 분석 상태(COMPLETED, PROCESSING 등)
+        LocalDateTime createdAt // 분석 요청 일시
+) {
+    public static ResumeAnalysisListResponse from(ResumeAnalysisReport report){
+        return new ResumeAnalysisListResponse(
+                report.getId(),
+                report.getResume().getTitle(),               // 연관된 이력서에서 제목 추출
+                report.getJobPosting().getCompanyName(),     // 연관된 공고에서 회사명 추출
+                report.getJobPosting().getJobTitle(),        // 연관된 공고에서 직무 추출
+                report.getMatchScore(),
+                report.getStatus().name(),
+                report.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/interview/InterviewResultStatisticsRepositoryCustom.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/interview/InterviewResultStatisticsRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.aibe.team2.domain.statistics.repository.interview;
 
 import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import com.querydsl.core.Tuple;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface InterviewResultStatisticsRepositoryCustom {
 
-    // 특정 회원의 통계 결화를 조회하며, 면접 타입(TEXT/VOICE)에 따라 동적 필터링을 수행
+    // 1. 특정 회원의 통계 결과를 조회하며, 면접 타입(TEXT/VOICE)에 따라 동적 필터링을 수행
     List<InterviewResultStatistics> findStatisticsByCondition(Long memberId, String sessionType);
+
+    // 2. [추가된 튜플 메서드] 특정 기간 동안의 6개 지표 평균 계산
+    Tuple findAverageMetricsTupleByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/interview/InterviewResultStatisticsRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/interview/InterviewResultStatisticsRepositoryImpl.java
@@ -1,12 +1,14 @@
 package com.aibe.team2.domain.statistics.repository.interview;
 
 import com.aibe.team2.domain.statistics.entity.InterviewResultStatistics;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.aibe.team2.domain.interview.entity.QInterviewSession.interviewSession;
@@ -33,6 +35,26 @@ public class InterviewResultStatisticsRepositoryImpl implements InterviewResultS
                 .fetch();
     }
 
+    @Override
+    public Tuple findAverageMetricsTupleByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end) {
+        return queryFactory
+                .select(
+                        interviewResultStatistics.avgClarity.avg(),
+                        interviewResultStatistics.avgPersuasiveness.avg(),
+                        interviewResultStatistics.avgConsistency.avg(),
+                        interviewResultStatistics.jobRelevanceScore.avg(),
+                        interviewResultStatistics.logicalStructureScore.avg(),
+                        interviewResultStatistics.attitudeConfidenceScore.avg()
+                )
+                .from(interviewResultStatistics)
+                .join(interviewResultStatistics.interviewSession, interviewSession)
+                .where(
+                        memberIdEq(memberId), // 기존에 만들어둔 재사용 가능한 조건 메서드 활용
+                        createdAtBetween(start, end) // 기간 필터링 조건 메서드 호출
+                )
+                .fetchOne();
+    }
+
     // 동적 쿼리를 위한 BooleanExpression 메서드
     // 1. 회원 ID 일치 여부(필수 조건)
     private BooleanExpression memberIdEq(Long memberId) {
@@ -46,5 +68,13 @@ public class InterviewResultStatisticsRepositoryImpl implements InterviewResultS
     private BooleanExpression sessionTypeEq(String sessionType) {
 
         return StringUtils.hasText(sessionType) ? interviewSession.interviewType.eq(sessionType) : null;
+    }
+
+    // 3. 생성일자 기간 필터링 조건
+    private BooleanExpression createdAtBetween(LocalDateTime start, LocalDateTime end) {
+        if(start == null || end == null) {
+            return null;
+        }
+        return interviewResultStatistics.createdAt.between(start, end);
     }
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/service/GrowthStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/GrowthStatisticsService.java
@@ -6,6 +6,7 @@ import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
 import com.aibe.team2.domain.statistics.repository.interview.InterviewResultStatisticsRepository;
 import com.aibe.team2.domain.statistics.util.GrowthCalculator;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.NumberExpression;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,35 +67,25 @@ public class GrowthStatisticsService {
         Tuple prevTuple = interviewResultStatisticsRepository.findAverageMetricsTupleByMemberIdAndCreatedAtBetween(
                 memberId, previousMonthStart, previousMonthEnd);
 
-        // 명확성 점수
-        growthResults.add(GrowthCalculator.calculateGrowth("명확성 점수",
-                getSafeScore(prevTuple, interviewResultStatistics.avgClarity.avg()),
-                getSafeScore(currTuple, interviewResultStatistics.avgClarity.avg())));
+        // [리팩토링] 순서가 완벽히 보장되는 List와 Record를 활용한 반복문 처리
+        record Metric(String name, NumberExpression<Double> expression) {}
 
-        // 설득력 점수
-        growthResults.add(GrowthCalculator.calculateGrowth("설득력 점수",
-                getSafeScore(prevTuple, interviewResultStatistics.avgPersuasiveness.avg()),
-                getSafeScore(currTuple, interviewResultStatistics.avgPersuasiveness.avg())));
+        List<Metric> metrics = List.of(
+                new Metric("명확성 점수", interviewResultStatistics.avgClarity.avg()),
+                new Metric("설득력 점수", interviewResultStatistics.avgPersuasiveness.avg()),
+                new Metric("일관성 점수", interviewResultStatistics.avgConsistency.avg()),
+                new Metric("직무 적합성 점수", interviewResultStatistics.jobRelevanceScore.avg()),
+                new Metric("논리적 구조 점수", interviewResultStatistics.logicalStructureScore.avg()),
+                new Metric("태도 및 자신감 점수", interviewResultStatistics.attitudeConfidenceScore.avg())
+        );
 
-        // 일관성 점수
-        growthResults.add(GrowthCalculator.calculateGrowth("일관성 점수",
-                getSafeScore(prevTuple, interviewResultStatistics.avgConsistency.avg()),
-                getSafeScore(currTuple, interviewResultStatistics.avgConsistency.avg())));
-
-        // 직무 적합성 점수
-        growthResults.add(GrowthCalculator.calculateGrowth("직무 적합성 점수",
-                getSafeScore(prevTuple, interviewResultStatistics.jobRelevanceScore.avg()),
-                getSafeScore(currTuple, interviewResultStatistics.jobRelevanceScore.avg())));
-
-        // 논리적 구조 점수
-        growthResults.add(GrowthCalculator.calculateGrowth("논리적 구조 점수",
-                getSafeScore(prevTuple, interviewResultStatistics.logicalStructureScore.avg()),
-                getSafeScore(currTuple, interviewResultStatistics.logicalStructureScore.avg())));
-
-        // 태도 및 자신감 점수
-        growthResults.add(GrowthCalculator.calculateGrowth("태도 및 자신감 점수",
-                getSafeScore(prevTuple, interviewResultStatistics.attitudeConfidenceScore.avg()),
-                getSafeScore(currTuple, interviewResultStatistics.attitudeConfidenceScore.avg())));
+        metrics.forEach(metric ->
+                growthResults.add(GrowthCalculator.calculateGrowth(
+                        metric.name(),
+                        getSafeScore(prevTuple, metric.expression()),
+                        getSafeScore(currTuple, metric.expression())
+                ))
+        );
 
         return growthResults;
     }

--- a/src/main/java/com/aibe/team2/domain/statistics/service/GrowthStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/GrowthStatisticsService.java
@@ -91,7 +91,7 @@ public class GrowthStatisticsService {
     }
 
     // 튜플 전용 헬퍼 메서드
-    private BigDecimal getSafeScore(Tuple tuple, com.querydsl.core.types.dsl.NumberExpression<Double> expression) {
+    private BigDecimal getSafeScore(Tuple tuple, NumberExpression<Double> expression) {
         if (tuple == null || tuple.get(expression) == null) {
             // 값이 아예 없을 때도 "0.00"으로 포맷을 예쁘게 맞춰줍니다.
             return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);

--- a/src/main/java/com/aibe/team2/domain/statistics/service/GrowthStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/GrowthStatisticsService.java
@@ -1,0 +1,113 @@
+package com.aibe.team2.domain.statistics.service;
+
+import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
+import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
+import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
+import com.aibe.team2.domain.statistics.repository.interview.InterviewResultStatisticsRepository;
+import com.aibe.team2.domain.statistics.util.GrowthCalculator;
+import com.querydsl.core.Tuple;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.aibe.team2.domain.statistics.entity.QInterviewResultStatistics.interviewResultStatistics;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GrowthStatisticsService {
+
+    private final ResumeAnalysisRepository resumeAnalysisRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewResultStatisticsRepository interviewResultStatisticsRepository;
+
+    public List<GrowthResultResponse> getGrowthStatistics(Long memberId) {
+        List<GrowthResultResponse> growthResults = new ArrayList<>();
+
+        // 1. 기간 설정 - 이번 달과 지난달의 시작/종료 시간 계산
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime currentMonthStart = YearMonth.now().atDay(1).atStartOfDay();
+        LocalDateTime previousMonthStart = YearMonth.now().minusMonths(1).atDay(1).atStartOfDay();
+        LocalDateTime previousMonthEnd = currentMonthStart.minusNanos(1);
+
+        // 2. 이력서 수정 횟수 집계 - 제공된 쿼리 메서드 활용
+        long currResumeEdits = resumeAnalysisRepository.countByMemberIdAndCreatedAtBetween(
+                memberId, currentMonthStart, now);
+        long prevResumeEdits = resumeAnalysisRepository.countByMemberIdAndCreatedAtBetween(
+                memberId, previousMonthStart, previousMonthEnd);
+        growthResults.add(GrowthCalculator.calculateGrowth(
+                "이력서 수정 횟수",
+                BigDecimal.valueOf(prevResumeEdits),
+                BigDecimal.valueOf(currResumeEdits)
+        ));
+
+        // 3. 모의 면접 횟수 집계
+        long currInterviews = interviewSessionRepository.countByMemberIdAndCreatedAtBetween(
+                memberId, currentMonthStart, now);
+        long prevInterviews = interviewSessionRepository.countByMemberIdAndCreatedAtBetween(
+                memberId, previousMonthStart, previousMonthEnd);
+
+        growthResults.add(GrowthCalculator.calculateGrowth(
+                "모의 면접 횟수",
+                BigDecimal.valueOf(prevInterviews),
+                BigDecimal.valueOf(currInterviews)
+        ));
+
+        // 4. 답변 정확도 평균 집계
+        Tuple currTuple = interviewResultStatisticsRepository.findAverageMetricsTupleByMemberIdAndCreatedAtBetween(
+                memberId, currentMonthStart, now);
+        Tuple prevTuple = interviewResultStatisticsRepository.findAverageMetricsTupleByMemberIdAndCreatedAtBetween(
+                memberId, previousMonthStart, previousMonthEnd);
+
+        // 명확성 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("명확성 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.avgClarity.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.avgClarity.avg())));
+
+        // 설득력 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("설득력 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.avgPersuasiveness.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.avgPersuasiveness.avg())));
+
+        // 일관성 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("일관성 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.avgConsistency.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.avgConsistency.avg())));
+
+        // 직무 적합성 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("직무 적합성 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.jobRelevanceScore.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.jobRelevanceScore.avg())));
+
+        // 논리적 구조 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("논리적 구조 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.logicalStructureScore.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.logicalStructureScore.avg())));
+
+        // 태도 및 자신감 점수
+        growthResults.add(GrowthCalculator.calculateGrowth("태도 및 자신감 점수",
+                getSafeScore(prevTuple, interviewResultStatistics.attitudeConfidenceScore.avg()),
+                getSafeScore(currTuple, interviewResultStatistics.attitudeConfidenceScore.avg())));
+
+        return growthResults;
+    }
+
+    // 튜플 전용 헬퍼 메서드
+    private BigDecimal getSafeScore(Tuple tuple, com.querydsl.core.types.dsl.NumberExpression<Double> expression) {
+        if (tuple == null || tuple.get(expression) == null) {
+            // 값이 아예 없을 때도 "0.00"으로 포맷을 예쁘게 맞춰줍니다.
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        // DB에서 꺼낸 Double 값을 BigDecimal로 바꾼 직후, 바로 소수점 둘째 자리에서 반올림!
+        return BigDecimal.valueOf(tuple.get(expression))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/service/ResumeStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/ResumeStatisticsService.java
@@ -3,6 +3,7 @@ package com.aibe.team2.domain.statistics.service;
 import com.aibe.team2.domain.resume.entity.ResumeAnalysisReport;
 import com.aibe.team2.domain.resume.entity.ResumeAnalysisStatus;
 import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
+import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisListResponse;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse.CorrectionDetail;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse.EvaluationSummary;
@@ -12,6 +13,8 @@ import com.aibe.team2.global.exception.custom.ForbiddenException;
 import com.aibe.team2.global.exception.custom.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,9 +25,15 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ResumeStatisticsService {
+public class                                          ResumeStatisticsService {
 
     private final ResumeAnalysisRepository resumeAnalysisRepository;
+
+    // [FR-REP-04] 자기소개서 첨삭 이력 조회
+    public Page<ResumeAnalysisListResponse> getResumeAnalysisList(long memberId, Pageable pageable) {
+        return resumeAnalysisRepository.findByMemberIdWithDetails(memberId, pageable)
+                .map(ResumeAnalysisListResponse::from);
+    }
 
     // [FR-REP-04] 자기소개서 첨삭 이력 - 상세 조회
     @Transactional(readOnly = true)

--- a/src/main/java/com/aibe/team2/domain/statistics/service/ResumeStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/ResumeStatisticsService.java
@@ -25,7 +25,7 @@ import java.util.Map;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class                                          ResumeStatisticsService {
+public class ResumeStatisticsService {
 
     private final ResumeAnalysisRepository resumeAnalysisRepository;
 

--- a/src/main/java/com/aibe/team2/domain/statistics/util/GrowthCalculator.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/util/GrowthCalculator.java
@@ -31,8 +31,8 @@ public class GrowthCalculator {
         if(previous.compareTo(BigDecimal.ZERO) == 0) {
             return GrowthResultResponse.builder()
                     .metricName(metricName)
-                    .previousValue(previous)
-                    .currentValue(current)
+                    .previousValue(roundedPrevious)
+                    .currentValue(roundedCurrent)
                     .difference(difference)
                     .growthRate(null) // 이전 값이 0이면 성장률 수치로 정의할 수 없음
                     .displayGrowthRate("신규 진입")

--- a/src/main/java/com/aibe/team2/domain/statistics/util/GrowthCalculator.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/util/GrowthCalculator.java
@@ -1,0 +1,57 @@
+package com.aibe.team2.domain.statistics.util;
+
+import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class GrowthCalculator {
+
+    // 인스턴스화 방지
+    private GrowthCalculator() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    // 성장률 계산 및 DTO 반환 메서드
+    public static GrowthResultResponse calculateGrowth(String metricName, BigDecimal previous, BigDecimal current) {
+
+        // null 방어
+        if(previous == null || current == null) {
+            throw new IllegalArgumentException("previous/current는 null일 수 없습니다.");
+        }
+
+        // 소수점 둘째 자리 반올림
+        BigDecimal roundedPrevious = previous.setScale(2, RoundingMode.HALF_UP);
+        BigDecimal roundedCurrent = current.setScale(2, RoundingMode.HALF_UP);
+
+        // 변화량 계산
+        BigDecimal difference = current.subtract(previous);
+
+        // 0으로 나누기 방지 및 신규 사용자 처리 로직
+        if(previous.compareTo(BigDecimal.ZERO) == 0) {
+            return GrowthResultResponse.builder()
+                    .metricName(metricName)
+                    .previousValue(previous)
+                    .currentValue(current)
+                    .difference(difference)
+                    .growthRate(null) // 이전 값이 0이면 성장률 수치로 정의할 수 없음
+                    .displayGrowthRate("신규 진입")
+                    .build();
+        }
+
+        // 성장률 계산 : (Difference / Previous) * 100
+        // 소수점 셋째 자리에서 반올림하여 둘째 자리까지 표현
+        BigDecimal growthRate = difference.divide(previous, 4, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return GrowthResultResponse.builder()
+                .metricName(metricName)
+                .previousValue(roundedPrevious)
+                .currentValue(roundedCurrent)
+                .difference(difference)
+                .growthRate(growthRate)
+                .displayGrowthRate(growthRate.toString() + "%")
+                .build();
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/statistics/util/GrowthCalculator.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/util/GrowthCalculator.java
@@ -42,7 +42,7 @@ public class GrowthCalculator {
         // 성장률 계산 : (Difference / Previous) * 100
         // 소수점 셋째 자리에서 반올림하여 둘째 자리까지 표현
         BigDecimal growthRate = difference.divide(previous, 4, RoundingMode.HALF_UP)
-                .multiply(new BigDecimal("100"))
+                .multiply(BigDecimal.valueOf(100L))
                 .setScale(2, RoundingMode.HALF_UP);
 
         return GrowthResultResponse.builder()


### PR DESCRIPTION
## 관련 이슈
- closed: #77 

## 작업 내용
<!-- 기능에 대한 구체적인 내용을 작성해주세요 -->
- **[Repository]** QueryDSL 사용자 정의 레포지토리(`InterviewSessionRepositoryCustom`, `Impl`) 구현: 
  - `InterviewSession` 엔티티를 직접 수정하지 않고, `leftJoin().on()`을 활용한 Ad-hoc Join으로 연관된 자소서(`Resume`)와 채용공고(`JobPosting`) 데이터를 N+1 문제 없이 한 번에 조회하도록 최적화
  - `Projections.constructor`를 사용해 조회 결과를 DTO로 즉시 매핑
- **[DTO]** `InterviewSessionListResponse` 레코드 생성: 컴팩트 생성자를 활용하여 자소서나 공고 없이 진행된 '자유 면접'의 경우 Null 방어 로직("선택된 자소서 없음", "자유 면접" 텍스트 매핑)을 처리
- **[Service & Controller]** `MypageInterviewService`, `MypageInterviewController` 구현: `GET /api/v1/mypage/interviews` 엔드포인트를 열고 프론트엔드 페이징 파라미터를 연동

<br/>

## 변경 사항 및 주의 사항
- **아키텍처(패키지) 분리:** - 데이터베이스에 접근하는 Repository 관련 클래스들은 데이터 소유권에 따라 `domain.interview.repository`에 위치시켰습니다.
  - 마이페이지 화면 렌더링을 위한 전용 DTO, Service, Controller는 화면 소유권에 따라 `domain.mypage` 하위 패키지로 분리하여 결합도를 낮췄습니다.
- **타 도메인 엔티티 보호:** 다른 팀원이 담당하는 `InterviewSession` 엔티티의 연관관계 매핑을 임의로 수정하지 않고, QueryDSL로만 조인을 해결하여 타 도메인의 코드 안정성을 보장했습니다.
- **Spring Security (TODO):** 현재 `MypageInterviewController` 내 사용자 식별 부분은 `Long currentUserId = 1L;`로 임시 하드코딩 되어 있습니다. 추후 Security 연동 시 교체 예정입니다.

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

