### PR TITLE
[FIX] AttachmentService 연관관계 getter 수정 #85

### DIFF
--- a/src/main/java/com/aibe/team2/domain/file/service/AttachmentService.java
+++ b/src/main/java/com/aibe/team2/domain/file/service/AttachmentService.java
@@ -97,7 +97,7 @@ public class AttachmentService {
                         .orElseThrow(() -> new BusinessException(ErrorCode.COMMON_404));
 
                 // TODO: 아래 getter는 엔티티 구조에 맞춰 조정
-                Long sessionId = record.getInterviewSessionId();
+                Long sessionId = record.getInterviewSession().getId();
 
                 var session = interviewSessionRepository.findById(sessionId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.COMMON_404));
@@ -113,7 +113,7 @@ public class AttachmentService {
                 var report = resumeAnalysisRepository.findById(targetId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.COMMON_404));
 
-                Long resumeId = report.getResumeId();
+                Long resumeId = report.getResume().getId();
 
                 var resume = resumeRepository.findById(resumeId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.COMMON_404));


### PR DESCRIPTION
## 관련 이슈
- closed: #85

## 작업 내용
AttachmentService에서 getInterviewSessionId(), getResumeId() 호출
실제 엔티티는 연관관계 객체 매핑 구조
develop 브랜치 빌드 실패 발생

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다