### PR TITLE
[FEAT] Redis 기반 API Rate Limit 인프라 구축 및 마이페이지 도메인 적용

### DIFF
--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
@@ -2,6 +2,7 @@ package com.aibe.team2.domain.mypage.controller;
 
 import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import com.aibe.team2.domain.mypage.service.MypageInterviewService;
+import com.aibe.team2.global.redis.ratelimit.RateLimit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,6 +20,7 @@ public class MypageInterviewController {
 
     private final MypageInterviewService mypageInterviewService;
 
+    @RateLimit
     @GetMapping
     public ResponseEntity<Page<InterviewSessionListResponse>> getInterviewSessionList(
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/DailyStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/DailyStatisticsController.java
@@ -3,6 +3,7 @@ package com.aibe.team2.domain.statistics.controller;
 import com.aibe.team2.domain.statistics.dto.DailyStatisticsResponse;
 import com.aibe.team2.domain.statistics.service.DailyStatisticsService;
 import com.aibe.team2.global.common.response.ApiResponse;
+import com.aibe.team2.global.redis.ratelimit.RateLimit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +17,7 @@ public class DailyStatisticsController {
 
     // [FR-STA-02] 일 단위 통계 집계 API
     // GET /api/v1/mypage/statistics?targetDate=2026-02-26
+    @RateLimit
     @GetMapping
     public ResponseEntity<ApiResponse<DailyStatisticsResponse>> getDailyStatistics(
             // TODO : Spring Security 적용 후 주석 해제 및 Mock-Member-Id 제거

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/GrowthStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/GrowthStatisticsController.java
@@ -2,6 +2,7 @@ package com.aibe.team2.domain.statistics.controller;
 
 import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
 import com.aibe.team2.domain.statistics.service.GrowthStatisticsService;
+import com.aibe.team2.global.redis.ratelimit.RateLimit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ public class GrowthStatisticsController {
 
     private final GrowthStatisticsService growthStatisticsService;
 
+    @RateLimit
     @GetMapping("/statistics/growth")
     public ResponseEntity<List<GrowthResultResponse>>getGrowthStatistics(
             // TODO : Spring Security 구현 후 수정

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/MemberStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/MemberStatisticsController.java
@@ -2,6 +2,7 @@ package com.aibe.team2.domain.statistics.controller;
 
 import com.aibe.team2.domain.statistics.dto.usage.MonthlyUsageResponse;
 import com.aibe.team2.domain.statistics.service.MemberStatisticsService;
+import com.aibe.team2.global.redis.ratelimit.RateLimit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +21,7 @@ public class MemberStatisticsController {
 
     // [FR-STA-01] 월별 사용량 조회
     // GET /api/v1/mypage/ai-usage
+    @RateLimit
     @GetMapping("/ai-usage")
     public ResponseEntity<MonthlyUsageResponse> getMonthlyAiUsage(
             // TODO : Spring Security 구현 후 주석 해제 및 임시 memberId 파라미터 삭제 필요

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/ResumeStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/ResumeStatisticsController.java
@@ -3,6 +3,7 @@ package com.aibe.team2.domain.statistics.controller;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisListResponse;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse;
 import com.aibe.team2.domain.statistics.service.ResumeStatisticsService;
+import com.aibe.team2.global.redis.ratelimit.RateLimit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -20,6 +21,7 @@ public class ResumeStatisticsController {
     private final ResumeStatisticsService resumeStatisticsService;
 
     // [FR-REP-04] 자기소개서 첨삭 이력 조회
+    @RateLimit
     @GetMapping("/analysis")
     public ResponseEntity<Page<ResumeAnalysisListResponse>> getResumeAnalysisList(
             @RequestParam(defaultValue = "0") int page, // URL 파라미터: 시작 페이지 (기본 0)

--- a/src/main/java/com/aibe/team2/domain/statistics/service/DailyStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/DailyStatisticsService.java
@@ -62,7 +62,7 @@ public class DailyStatisticsService {
         if(targetDate.isEqual(LocalDate.now())) {
             operations.set(redisKey, statsDto, Duration.ofMinutes(5));
         } else {
-            operations.set(redisKey, statsDto, Duration.ofMinutes(1));
+            operations.set(redisKey, statsDto, Duration.ofDays(1));
         }
 
         return statsDto;

--- a/src/main/java/com/aibe/team2/domain/statistics/service/DailyStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/DailyStatisticsService.java
@@ -58,8 +58,12 @@ public class DailyStatisticsService {
         log.info("Cache Miss 발생! DB 집계 시작! 키: {}", redisKey);
         DailyStatisticsResponse statsDto = aggregateFromDb(memberId, targetDate);
 
-        // 5. Redis에 저장(TTL 설정 : 자정까지)
-        operations.set(redisKey, statsDto, Duration.ofDays(1));
+        // 날짜에 따른 동적 TTL 설정
+        if(targetDate.isEqual(LocalDate.now())) {
+            operations.set(redisKey, statsDto, Duration.ofMinutes(5));
+        } else {
+            operations.set(redisKey, statsDto, Duration.ofMinutes(1));
+        }
 
         return statsDto;
     }

--- a/src/main/java/com/aibe/team2/global/config/WebMvcConfig.java
+++ b/src/main/java/com/aibe/team2/global/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package com.aibe.team2.global.config;
+
+import com.aibe.team2.global.redis.ratelimit.RateLimitInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final RateLimitInterceptor rateLimitInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+
+        registry.addInterceptor(rateLimitInterceptor)
+                .addPathPatterns("/**"); // 애플리케이션의 모든 요청 경로를 가로챔
+    }
+}

--- a/src/main/java/com/aibe/team2/global/error/ErrorCode.java
+++ b/src/main/java/com/aibe/team2/global/error/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     COMMON_407(HttpStatus.BAD_REQUEST, "COMMON_407", "필수 파라미터가 누락되었습니다."),
     COMMON_408(HttpStatus.BAD_REQUEST, "COMMON_408", "유효하지 않은 파라미터입니다."),
     COMMON_409(HttpStatus.CONFLICT, "COMMON_409", "요청이 현재 상태와 충돌합니다."),
+    COMMON_429(HttpStatus.TOO_MANY_REQUESTS, "COMMON_429", "너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요."),
     COMMON_500(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 내부 오류가 발생했습니다."),
     COMMON_JSON_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_501", "JSON 데이터 변환 중 오류가 발생했습니다."),
 

--- a/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimit.java
+++ b/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimit.java
@@ -13,6 +13,6 @@ public @interface RateLimit {
     // 허용되는 최대 요청 횟수(기본값 10회)
     int maxRequests() default 10;
 
-    // 제한을 두는 기준 시간(기본값 60초)
+    // 제한을 두는 기준 시간(기본값 10초)
     long durationSeconds() default 10;
 }

--- a/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimit.java
+++ b/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimit.java
@@ -1,0 +1,18 @@
+package com.aibe.team2.global.redis.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// API Rate Limiting 적용을 위한 커스텀 어노테이션
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+
+    // 허용되는 최대 요청 횟수(기본값 10회)
+    int maxRequests() default 10;
+
+    // 제한을 두는 기준 시간(기본값 60초)
+    long durationSeconds() default 10;
+}

--- a/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimitInterceptor.java
@@ -49,27 +49,48 @@ public class RateLimitInterceptor implements HandlerInterceptor {
         return true;
     }
 
+    // 1. 클라이언트 식별자를 결정하는 메인 메서드
     private String getClientIdentifier(HttpServletRequest request) {
-        return request.getRemoteAddr();
+
+        // TODO: Spring Security 구현 시, 주석을 해제하고 로그인 유저(ID) 식별 로직을 추가
+    /*
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication != null && authentication.isAuthenticated()) {
+        Object principal = authentication.getPrincipal();
+        if (!"anonymousUser".equals(principal)) {
+            return authentication.getName();
+        }
+    }
+    */
+
+        // 현재는 Security가 없으므로, 모든 요청을 비로그인 사용자로 간주하고 '진짜 클라이언트 IP'를 반환
+        return getRealClientIp(request);
     }
 
-    // TODO : Spring Security 구현 후 수정
-    // private String getClientIdentifier(HttpServletRequest request) {
-    //     // 1. SecurityContextHolder에서 현재 요청의 인증(Authentication) 정보를 가져옴
-    //     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    //
-    //     // 2. 인증 객체가 존재하고, 사용자가 로그인한 상태(인증됨)인지 검증
-    //     if (authentication != null && authentication.isAuthenticated()) {
-    //
-    //         // 3. 익명 사용자(비로그인 상태)가 아닌 경우에만 해당 사용자의 고유 ID를 반환
-    //         // principal이 "anonymousUser"인 경우는 Spring Security의 기본 익명 사용자 설정임
-    //         Object principal = authentication.getPrincipal();
-    //         if (!principal.equals("anonymousUser")) {
-    //             return authentication.getName(); // 보통 JWT의 subject(유저 식별자)가 반환됨
-    //         }
-    //     }
-    //
-    //     // 4. Fallback (대체 수단): 비로그인 사용자가 접근 가능한 API의 경우 기존처럼 IP 주소 반환
-    //     return request.getRemoteAddr();
-    // }
+    // 2. 프록시 환경을 고려하여 실제 클라이언트 IP를 추출하는 헬퍼 메서드
+    private String getRealClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+
+        if (ip != null && ip.contains(",")) {
+            ip = ip.split(",")[0].trim();
+        }
+
+        return ip;
+    }
 }

--- a/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,75 @@
+package com.aibe.team2.global.redis.ratelimit;
+
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+// 💡 핵심 해결: implements HandlerInterceptor 추가
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final RateLimiterService rateLimiterService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        if(!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        // 주의: 이 부분에서 에러가 난다면 RateLimit.java(어노테이션) 파일이 생성되어 있는지 꼭 확인해 줘!
+        RateLimit rateLimit = handlerMethod.getMethodAnnotation(RateLimit.class);
+        if(rateLimit == null) {
+            return true;
+        }
+
+        String clientIdentifier = getClientIdentifier(request);
+        String rateLimitKey = clientIdentifier + ":" + request.getRequestURI();
+
+        Duration duration = Duration.ofSeconds(rateLimit.durationSeconds());
+        boolean isAllowed = rateLimiterService.isAllowed(rateLimitKey, rateLimit.maxRequests(), duration);
+
+        if (!isAllowed) {
+            log.warn("Rate limit exceeded for identifier: {}", clientIdentifier);
+            throw new BusinessException(ErrorCode.COMMON_429);
+        }
+
+        return true;
+    }
+
+    private String getClientIdentifier(HttpServletRequest request) {
+        return request.getRemoteAddr();
+    }
+
+    // TODO : Spring Security 구현 후 수정
+    // private String getClientIdentifier(HttpServletRequest request) {
+    //     // 1. SecurityContextHolder에서 현재 요청의 인증(Authentication) 정보를 가져옴
+    //     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    //
+    //     // 2. 인증 객체가 존재하고, 사용자가 로그인한 상태(인증됨)인지 검증
+    //     if (authentication != null && authentication.isAuthenticated()) {
+    //
+    //         // 3. 익명 사용자(비로그인 상태)가 아닌 경우에만 해당 사용자의 고유 ID를 반환
+    //         // principal이 "anonymousUser"인 경우는 Spring Security의 기본 익명 사용자 설정임
+    //         Object principal = authentication.getPrincipal();
+    //         if (!principal.equals("anonymousUser")) {
+    //             return authentication.getName(); // 보통 JWT의 subject(유저 식별자)가 반환됨
+    //         }
+    //     }
+    //
+    //     // 4. Fallback (대체 수단): 비로그인 사용자가 접근 가능한 API의 경우 기존처럼 IP 주소 반환
+    //     return request.getRemoteAddr();
+    // }
+}

--- a/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimiterService.java
+++ b/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimiterService.java
@@ -1,0 +1,37 @@
+package com.aibe.team2.global.redis.ratelimit;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RateLimiterService {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /*
+     * API 호출 처리율 제한(Rate Limiting) 검증 로직
+     *
+     * @param key 식별 키 (Client IP 또는 User ID)
+     * @param maxRequests 허용되는 최대 요청 횟수 (Maximum Requests)
+     * @param duration 제한 기준 시간 (Time Window)
+     * @return 허용 여부 (true: 통과, false: 차단)
+     */
+
+    public boolean isAllowed(String key, int maxRequests, Duration duration){
+        String rateLimiterKey = "rate_limiter:" + key;
+
+        // 원자적 증가 연산
+        Long currentCount = stringRedisTemplate.opsForValue().increment(rateLimiterKey);
+
+        // 키가 최초 생성된 경우(값이 1인 경우)에만 만료 시간 할당
+        if(currentCount != null && currentCount == 1L) {
+            stringRedisTemplate.expire(rateLimiterKey, duration);
+        }
+
+        // 임계치 검증 후 반환
+        return currentCount != null && currentCount <= maxRequests;
+    }
+}

--- a/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimiterService.java
+++ b/src/main/java/com/aibe/team2/global/redis/ratelimit/RateLimiterService.java
@@ -2,14 +2,28 @@ package com.aibe.team2.global.redis.ratelimit;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
 public class RateLimiterService {
     private final StringRedisTemplate stringRedisTemplate;
+
+    // 1. Lua 스크립트 상수로 정의
+    private static final String RATE_LIMIT_SCRIPT =
+            "local current = redis.call('INCR', KEYS[1]) " +
+                    "if current == 1 then " +
+                    "    redis.call('EXPIRE', KEYS[1], ARGV[1]) " +
+                    "end " +
+                    "return current";
+
+    // 2. 실행할 스크립트 객체 미리 생성
+    private final RedisScript<Long> redisScript = new DefaultRedisScript<>(RATE_LIMIT_SCRIPT, Long.class);
 
     /*
      * API 호출 처리율 제한(Rate Limiting) 검증 로직
@@ -23,15 +37,14 @@ public class RateLimiterService {
     public boolean isAllowed(String key, int maxRequests, Duration duration){
         String rateLimiterKey = "rate_limiter:" + key;
 
-        // 원자적 증가 연산
-        Long currentCount = stringRedisTemplate.opsForValue().increment(rateLimiterKey);
+        // 3. 스크립트 실행(원자적 연산(증가))
+        Long currentCount = stringRedisTemplate.execute(
+                redisScript,
+                Collections.singletonList(rateLimiterKey),      // KEYS[1]에 매핑될 데이터
+                String.valueOf(duration.getSeconds())           // ARGV[1]에 매핑될 데이터 (초 단위 변환)
+        );
 
-        // 키가 최초 생성된 경우(값이 1인 경우)에만 만료 시간 할당
-        if(currentCount != null && currentCount == 1L) {
-            stringRedisTemplate.expire(rateLimiterKey, duration);
-        }
-
-        // 임계치 검증 후 반환
+        // 4. 임계치 검증 후 반환
         return currentCount != null && currentCount <= maxRequests;
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #81 

## 작업 내용
- `@RateLimit`: API 메서드에 개별적으로 제한 조건을 설정할 수 있는 커스텀 어노테이션 생성
- `RateLimiterService` & `RateLimitInterceptor`: Redis를 활용하여 제한 시간 내 요청 횟수를 카운트하고 차단하는 핵심 로직 구현
- `WebMvcConfig`: 스프링 인터셉터 레지스트리에 `RateLimitInterceptor` 등록
- `ErrorCode`: 호출 횟수 초과 시 반환할 `COMMON_429 (Too Many Requests)` 에러 코드 추가

<br/>

## 변경 사항 및 주의 사항
- **독립적인 카운트 관리 (Key Separation):** 인터셉터에서 식별자를 `IP 주소 + URI` 조합으로 구성했습니다. 따라서 A API를 10번 호출하여 차단되더라도, B API는 정상적으로 호출할 수 있습니다.
* **옵트인(Opt-in) 적용 방식:** 이 기능은 컨트롤러 메서드 위에 `@RateLimit` 어노테이션을 명시적으로 선언한 곳에서만 작동합니다. 면접 완료, 자기소개서 분석 등 다른 도메인을 담당하시는 팀원분들의 기존 API에는 아무런 영향을 주지 않습니다.
* **팀원 활용 안내:** 외부 API 연동이나 무거운 연산이 포함된 엔드포인트에 트래픽 제어가 필요하시다면, 해당 컨트롤러 메서드 위에 `@RateLimit(maxRequests = 횟수, durationSeconds = 초)`를 자유롭게 추가하여 사용하시면 됩니다.
<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

