### PR TITLE
[Feat] Redisson 동시성 제어 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // Redisson
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+    // Spring AOP (DistributedLockAspect 사용을 위해 필요)
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     // Security & JWT
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -54,9 +58,7 @@ dependencies {
 
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    
     implementation 'org.jsoup:jsoup:1.13.1'
 
     // Spring Batch

--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -1,7 +1,6 @@
 package com.aibe.team2.domain.interview.controller;
 
 import com.aibe.team2.domain.interview.dto.InterviewStartRequest;
-import com.aibe.team2.domain.interview.dto.UserAnswerRequest;
 import com.aibe.team2.domain.interview.dto.VoiceSessionResponse;
 import com.aibe.team2.domain.interview.entity.InterviewSession;
 import com.aibe.team2.domain.interview.service.ConversationManager;

--- a/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
@@ -1,6 +1,7 @@
 package com.aibe.team2.domain.interview.service;
 
 import com.aibe.team2.domain.interview.dto.VoiceSessionResponse;
+import com.aibe.team2.global.redis.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -13,6 +14,8 @@ public class ConversationManager {
     private final GeminiService geminiService;
     private final RetellService retellService;
 
+    // 락 키 예시: "interview-answer:15" (세션 ID 15번에 대해 락이 걸림)
+    @DistributedLock(key = "text-streaming", waitTime = 1, leaseTime = 20)
     public void startTextStreaming(String answer, SseEmitter emitter) {
         geminiService.streamQuestion(answer).subscribe(
                 data -> {
@@ -22,12 +25,13 @@ public class ConversationManager {
                         emitter.completeWithError(e);
                     }
                 },
-                error -> emitter.completeWithError(error),
+                emitter::completeWithError,
                 emitter::complete
         );
     }
 
-    // 음성 면접: 무조건 Retell 세션 생성 사용
+    // 음성 면접: Retell 세션 생성 사용
+    @DistributedLock(key = "voice-interview", waitTime = 1, leaseTime = 20)
     public VoiceSessionResponse startVoiceInterview(Long sessionId) {
         return retellService.createVoiceCall(sessionId);
     }

--- a/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
@@ -14,7 +14,8 @@ public class ConversationManager {
     private final GeminiService geminiService;
     private final RetellService retellService;
 
-    // 락 키 예시: "interview-answer:15" (세션 ID 15번에 대해 락이 걸림)
+    // 락 키 예시: "text-streaming:15" (세션 ID 15번에 대해 락이 걸림)
+    // waitTime = 1 , leaseTime = " 면접 세션 만드는 시간 + 5초 " 설정 할 것.
     @DistributedLock(key = "text-streaming", waitTime = 1, leaseTime = 20)
     public void startTextStreaming(String answer, SseEmitter emitter) {
         geminiService.streamQuestion(answer).subscribe(
@@ -31,6 +32,7 @@ public class ConversationManager {
     }
 
     // 음성 면접: Retell 세션 생성 사용
+    // waitTime = 1 , leaseTime = " 면접 세션 만드는 시간 + 5초 " 설정 할 것.
     @DistributedLock(key = "voice-interview", waitTime = 1, leaseTime = 20)
     public VoiceSessionResponse startVoiceInterview(Long sessionId) {
         return retellService.createVoiceCall(sessionId);

--- a/src/main/java/com/aibe/team2/domain/interview/service/InterviewManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/InterviewManager.java
@@ -3,6 +3,7 @@ package com.aibe.team2.domain.interview.service;
 import com.aibe.team2.domain.interview.entity.InterviewSession;
 import com.aibe.team2.domain.interview.entity.InterviewSessionStatus;
 import com.aibe.team2.domain.interview.repository.InterviewRepository;
+import com.aibe.team2.global.redis.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,15 +14,17 @@ public class InterviewManager {
 
     private final InterviewRepository interviewRepository;
 
+    // 락 키는 "interview-start:memberId:resumeId:..." 형태로 동적 생성됩니다.
+    @DistributedLock(key = "interview-start", waitTime = 1, leaseTime = 3)
     @Transactional
-    public InterviewSession startInterview(Long memberId, Long resumeId, Long jobPostingId, String mode, String type, String aiProvider) {
+    public InterviewSession startInterview(Long memberId, Long resumeId, Long jobPostingId, String interviewMode, String interviewType, String aiProvider) {
         InterviewSession session = InterviewSession.builder()
-                .memberId(memberId)      // ERD: member_id
-                .resumeId(resumeId)      // ERD: resume_id
-                .jobPostingId(jobPostingId) // ERD: job_posting_id
-                .interviewMode(mode)     // ERD: interview_mode
-                .interviewType(type)     // ERD: interview_type
-                .aiProvider(aiProvider) // 사용자 선택 반영
+                .memberId(memberId)
+                .resumeId(resumeId)
+                .jobPostingId(jobPostingId)
+                .interviewMode(interviewMode)
+                .interviewType(interviewType)
+                .aiProvider(aiProvider)
                 .build();
 
         return interviewRepository.save(session);

--- a/src/main/java/com/aibe/team2/domain/resume/service/ResumeAnalysisService.java
+++ b/src/main/java/com/aibe/team2/domain/resume/service/ResumeAnalysisService.java
@@ -10,6 +10,7 @@ import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
 import com.aibe.team2.domain.resume.repository.ResumeRepository;
 import com.aibe.team2.global.error.ErrorCode;
 import com.aibe.team2.global.exception.BusinessException;
+import com.aibe.team2.global.redis.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -29,6 +30,7 @@ public class ResumeAnalysisService {
     private final JobPostingRepository jobPostingRepository;
     private final ApplicationEventPublisher eventPublisher;
 
+    @DistributedLock(key = "resume-analysis", waitTime = 2, leaseTime = 3)
     @Transactional
     public Long analyzeResume(Long resumeId, Long jobPostingId, Long memberId) {
 

--- a/src/main/java/com/aibe/team2/global/redis/RedisConfig.java
+++ b/src/main/java/com/aibe/team2/global/redis/RedisConfig.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +31,15 @@ public class RedisConfig {
 
     @Value("${spring.data.redis.port}")
     private int port;
+
+    // --- 1. Redisson 설정 (분산 락 용도) ---
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port);
+        return Redisson.create(config);
+    }
 
     // 1. 공통으로 사용할 JSON 직렬화 빈(Bean) 생성
     @Bean

--- a/src/main/java/com/aibe/team2/global/redis/lock/DistributedLock.java
+++ b/src/main/java/com/aibe/team2/global/redis/lock/DistributedLock.java
@@ -1,0 +1,20 @@
+package com.aibe.team2.global.redis.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    // 락의 식별자 접두사 (예: "resume-analysis")
+    String key();
+
+    // 락 획득 대기 시간 (기본 3초)
+    long waitTime() default 3L;
+
+    // 락 소유 시간 (기본 5초: 로직이 안 끝나도 5초 뒤 자동 해제하여 데드락 방지)
+    long leaseTime() default 5L;
+}

--- a/src/main/java/com/aibe/team2/global/redis/lock/DistributedLockAspect.java
+++ b/src/main/java/com/aibe/team2/global/redis/lock/DistributedLockAspect.java
@@ -40,7 +40,7 @@ public class DistributedLockAspect {
             if (!isLocked) {
                 log.warn("[DistributedLock] 락 획득 실패. 중복 요청 방어됨. key: {}", lockKey);
                 // 중복 요청 시 예외 발생 (400 또는 409 에러)
-                throw new BusinessException(ErrorCode.COMMON_400);
+                throw new BusinessException(ErrorCode.COMMON_409);
             }
 
             // 락 획득 성공 시 비즈니스 로직 실행

--- a/src/main/java/com/aibe/team2/global/redis/lock/DistributedLockAspect.java
+++ b/src/main/java/com/aibe/team2/global/redis/lock/DistributedLockAspect.java
@@ -1,0 +1,69 @@
+package com.aibe.team2.global.redis.lock;
+
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Aspect
+@Component
+@Order(1) // @Transactional보다 먼저 실행되도록 우선순위 지정
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(com.aibe.team2.global.redis.lock.DistributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        DistributedLock distributedLock = signature.getMethod().getAnnotation(DistributedLock.class);
+
+        // 파라미터 값들을 조합하여 동적 Key 생성 (예: resume-analysis:15:2)
+        String dynamicKey = getDynamicKeyFromArgs(joinPoint.getArgs());
+        String lockKey = distributedLock.key() + ":" + dynamicKey;
+
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean isLocked = lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), TimeUnit.SECONDS);
+            if (!isLocked) {
+                log.warn("[DistributedLock] 락 획득 실패. 중복 요청 방어됨. key: {}", lockKey);
+                // 중복 요청 시 예외 발생 (400 또는 409 에러)
+                throw new BusinessException(ErrorCode.COMMON_400);
+            }
+
+            // 락 획득 성공 시 비즈니스 로직 실행
+            return joinPoint.proceed();
+
+        } catch (InterruptedException e) {
+            log.error("[DistributedLock] 락 대기 중 인터럽트 발생", e);
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } finally {
+            if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.debug("[DistributedLock] 락 반환 완료. key: {}", lockKey);
+            }
+        }
+    }
+
+    private String getDynamicKeyFromArgs(Object[] args) {
+        if (args == null || args.length == 0) return "default";
+        StringBuilder sb = new StringBuilder();
+        for (Object arg : args) {
+            sb.append(arg).append(":");
+        }
+        return sb.substring(0, sb.length() - 1);
+    }
+}


### PR DESCRIPTION
[Feat] Redisson 동시성 제어 기능 추가
1. build.gradle에 Redisson 의존성 추가
2. RedisConfig 메소드 추가
3. ResumeAnalysisService에 적용
4. DistributedLock/DistributedLockAspect 생성

[Refactor] 
1. InterviewSession Param 수정

<!-- 제목 예시: [feat] 관리자 페이지 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 관련 이슈
- closed: # 97 

## 작업 내용
<!-- 기능에 대한 구체적인 내용을 작성해주세요 -->
- AI 동시성 제어 : 
1.  0.01초 사이에 2개의 요청이 서버에 도달
2.  첫 번째 요청이 Redis에 달려가서 "15번 이력서 분석 열쇠(Lock)"를 차지
3.  0.001초 뒤에 도착한 두 번째 요청이 열쇠를 찾지만, 첫 번째가 가져갔으므로 "이미 진행 중인 작업입니다" 하고 튕겨 나감.
결과: 첫 번째 요청만 Gemini API를 정상적으로 1번 호출합니다. 요금 방어 완료




<br/>

## 변경 사항 및 주의 사항
<!-- 패키지, 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
- 

<br/>

## 체크 리스트
- [ ] PR 제목 규칙을 준수했습니다
- [ ] 관련 이슈를 연결했습니다
- [ ] 본문 내용을 명확하게 작성했습니다
- [ ] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- # 97 
