### PR TITLE
[FEAT] 마이페이지 프로필 이미지 S3 업로드 및 수정 기능 구현

### DIFF
--- a/src/main/java/com/aibe/team2/domain/file/service/S3ImageService.java
+++ b/src/main/java/com/aibe/team2/domain/file/service/S3ImageService.java
@@ -4,6 +4,7 @@ import com.aibe.team2.global.error.ErrorCode;
 import com.aibe.team2.global.exception.BusinessException;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,7 +17,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class S3ImageService {
 
@@ -40,10 +43,10 @@ public class S3ImageService {
             // 2. 404(Not Found) 에러가 나면 버킷이 없다는 뜻이므로 새로 생성
             if (e.statusCode() == 404) {
                 s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
-                System.out.println("✅ S3ImageService: 테스트용 버킷 [" + bucket + "] 자동 생성 완료!");
+                log.info("✅ S3ImageService: 테스트용 버킷 [{}] 자동 생성 완료!", bucket);
             }
         } catch (Exception e) {
-            System.err.println("버킷 확인 중 에러 발생: " + e.getMessage());
+            log.error("버킷 확인 중 에러 발생: {}", e.getMessage(), e);
         }
     }
 
@@ -89,7 +92,8 @@ public class S3ImageService {
                     .build();
 
             s3Client.deleteObject(deleteObjectRequest);
-        } catch (Exception e) {
+        } catch (S3Exception e) {
+            log.error("S3 파일 삭제 중 오류 발생: {}", e.getMessage());
             throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
         }
     }
@@ -101,7 +105,7 @@ public class S3ImageService {
         }
 
         if(file.getSize() > MAX_FILE_SIZE) {
-            throw new BusinessException(ErrorCode.COMMON_400);
+            throw new BusinessException(ErrorCode.FILE_SIZE_EXCEEDED);
         }
 
         String extension = getExtension(file.getOriginalFilename()).toLowerCase();

--- a/src/main/java/com/aibe/team2/domain/file/service/S3ImageService.java
+++ b/src/main/java/com/aibe/team2/domain/file/service/S3ImageService.java
@@ -1,0 +1,130 @@
+package com.aibe.team2.domain.file.service;
+
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.BusinessException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3ImageService {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    // 허용하는 이미지 확장자
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("jpg", "jpeg", "png");
+    // 최대 파일 크기 (5MB)
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+    // 버킷 생성
+    @PostConstruct
+    public void initBucket() {
+        try {
+            // 1. 버킷이 존재하는지 찔러보기
+            s3Client.headBucket(HeadBucketRequest.builder().bucket(bucket).build());
+        } catch (S3Exception e) {
+            // 2. 404(Not Found) 에러가 나면 버킷이 없다는 뜻이므로 새로 생성
+            if (e.statusCode() == 404) {
+                s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+                System.out.println("✅ S3ImageService: 테스트용 버킷 [" + bucket + "] 자동 생성 완료!");
+            }
+        } catch (Exception e) {
+            System.err.println("버킷 확인 중 에러 발생: " + e.getMessage());
+        }
+    }
+
+    // MultipartFile을 S3에 업로드하고 URL 반환
+    public String uploadProfileImage(MultipartFile file, Long memberId) {
+        validateImageFile(file);
+
+        String originalFilename = file.getOriginalFilename();
+        String extension = getExtension(originalFilename);
+
+        // 경로 : profiles/{memberId}/{UUID}.{확장자}
+        String s3Key = "profiles/" + memberId + "/" + UUID.randomUUID() + "." + extension;
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            // 업로드된 파일의 S3 접근 URL 생성(S3Client 활용)
+            return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(s3Key)).toExternalForm();
+        } catch (IOException e) {
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    // S3에서 기존 이미지 삭제
+    public void deleteImage(String fileUrl) {
+        if(fileUrl == null || fileUrl.isBlank()) {
+            return;
+        }
+
+        // URL에서 S3 Key 부분만 추출
+        String fileKey = extractKeyFromUrl(fileUrl);
+
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileKey)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
+    // 파일 확장자 및 크기 검사
+    private void validateImageFile(MultipartFile file) {
+        if(file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.FILE_EMPTY);
+        }
+
+        if(file.getSize() > MAX_FILE_SIZE) {
+            throw new BusinessException(ErrorCode.COMMON_400);
+        }
+
+        String extension = getExtension(file.getOriginalFilename()).toLowerCase();
+        if(!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new BusinessException(ErrorCode.FILE_EXTENSION_INVALID);
+        }
+    }
+
+    private String getExtension(String filename) {
+        if(filename == null || !filename.contains(".")) {
+            throw new BusinessException(ErrorCode.FILE_EXTENSION_INVALID);
+        }
+        return filename.substring(filename.lastIndexOf(".") + 1);
+    }
+
+    private String extractKeyFromUrl(String fileUrl) {
+        try {
+            java.net.URL url = new java.net.URL(fileUrl);
+            String path = url.getPath(); // 예: "/profiles/1/uuid.jpg" 또는 "/resumes/uuid.pdf"
+
+            return path.startsWith("/") ? path.substring(1) : path;
+        } catch (java.net.MalformedURLException e) {
+            throw new BusinessException(ErrorCode.COMMON_400); // 잘못된 URL 형식 예외 처리
+        }
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MemberController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.aibe.team2.domain.mypage.controller;
 
+import com.aibe.team2.domain.file.service.S3ImageService;
 import com.aibe.team2.domain.mypage.dto.response.MemberResponse;
 import com.aibe.team2.domain.mypage.dto.response.MemberUpdateResponse;
 import com.aibe.team2.domain.mypage.dto.request.PasswordChangeRequest;
@@ -9,8 +10,10 @@ import com.aibe.team2.domain.mypage.service.MemberService;
 import com.aibe.team2.global.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/mypage")
@@ -49,6 +52,25 @@ public class MemberController {
                 .code("OK")
                 .message("프로필 수정이 완료되었습니다.")
                 .data(response)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    // 마이페이지 프로필 이미지 변경
+    @PatchMapping(value = "/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<String>> updateProfileImage(
+            @RequestPart("file") MultipartFile file
+    ) {
+        Long memberId = getLoginMemberId();
+
+        String uploadedUrl = memberService.updateProfileImage(memberId, file);
+
+        ApiResponse<String> apiResponse = ApiResponse.<String> builder()
+                .success(true)
+                .code("OK")
+                .message("프로필 이미지 수정이 완료되었습니다.")
+                .data(uploadedUrl)
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
@@ -81,6 +81,10 @@ public class Member {
         if (profileImageUrl != null && !profileImageUrl.isEmpty()) this.profileImageUrl = profileImageUrl;
     }
 
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
     public void updatePassword(String encodedNewPassword) {
         this.password = encodedNewPassword;
     }
@@ -89,6 +93,7 @@ public class Member {
         this.desiredJobRole = desiredJobRole;
         this.preferredLocation = preferredLocation;
     }
+
     public void updateCreditBalance(int newBalance) {
         this.creditBalance = newBalance;
     }

--- a/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
@@ -133,8 +133,7 @@ public class MemberService {
     @Transactional
     public String updateProfileImage(Long memberId, MultipartFile file) {
         // 1. 회원 조회
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        Member member = memberRepository.getByIdThrow(memberId);
 
         // 삭제할 기존 이미지 URL을 미리 저장
         String oldImageUrl = member.getProfileImageUrl();

--- a/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.aibe.team2.domain.mypage.service;
 
+import com.aibe.team2.domain.file.service.S3ImageService;
 import com.aibe.team2.domain.mypage.dto.request.JobPreferenceUpdateRequest;
 import com.aibe.team2.domain.mypage.dto.request.PasswordChangeRequest;
 import com.aibe.team2.domain.mypage.dto.request.ProfileUpdate;
@@ -10,10 +11,12 @@ import com.aibe.team2.domain.mypage.repository.member.MemberRepository;
 import com.aibe.team2.domain.statistics.enums.ServiceType;
 import com.aibe.team2.domain.statistics.service.usage.UsageLogWriter;
 import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.BusinessException;
 import com.aibe.team2.global.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -26,6 +29,7 @@ public class MemberService {
     // TODO : Security Config에 PasswordEncoder Bean 등록 시 주석 풀기
     // private final PasswordEncoder passwordEncoder;
     private final UsageLogWriter usageLogWriter;
+    private final S3ImageService s3ImageService;
 
     // 1. 마이페이지 정보 조회
     public MemberResponse getMemberInfo(Long memberId){
@@ -124,5 +128,28 @@ public class MemberService {
         );
 
         return after;
+    }
+
+    @Transactional
+    public String updateProfileImage(Long memberId, MultipartFile file) {
+        // 1. 회원 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 삭제할 기존 이미지 URL을 미리 저장
+        String oldImageUrl = member.getProfileImageUrl();
+
+        // 2. 새 이미지 S3 업로드
+        String newImageUrl = s3ImageService.uploadProfileImage(file, memberId);
+
+        // 3. DB 엔티티의 profileImageUrl 필드 업데이트
+        member.updateProfileImage(newImageUrl);
+
+        // 4. 기존 이미지가 존재했다면 S3에서 삭제(새 이미지 업로드 및 DB 반영이 정상 진행된 후 실행)
+        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
+            s3ImageService.deleteImage(oldImageUrl);
+        }
+
+        return newImageUrl;
     }
 }

--- a/src/main/java/com/aibe/team2/global/init/DataInitializer.java
+++ b/src/main/java/com/aibe/team2/global/init/DataInitializer.java
@@ -5,6 +5,8 @@ import com.aibe.team2.domain.interview.repository.InterviewRepository;
 import com.aibe.team2.domain.jobposting.entity.JobPosting;
 import com.aibe.team2.domain.jobposting.repository.JobPostingRepository;
 import com.aibe.team2.domain.mypage.entity.Member;
+import com.aibe.team2.domain.mypage.entity.enums.Provider;
+import com.aibe.team2.domain.mypage.entity.enums.Role;
 import com.aibe.team2.domain.mypage.repository.member.MemberRepository;
 import com.aibe.team2.domain.resume.entity.Resume;
 import com.aibe.team2.domain.resume.entity.ResumeAnalysisReport;
@@ -26,7 +28,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 @Slf4j
-//@Component
+@Component
 @Profile("!prod") // 로컬이나 개발 환경에서만 이 빈이 활성화됨
 @RequiredArgsConstructor
 public class DataInitializer implements CommandLineRunner {
@@ -129,7 +131,8 @@ public class DataInitializer implements CommandLineRunner {
                    "tester" + i + "@synctalk.com",
                    "encodedPassword!",
                    "테스터" + i,
-                   null, null
+                   Role.MEMBER,
+                   Provider.LOCAL
            );
            members.add(memberRepository.save(member));
        }


### PR DESCRIPTION
## 관련 이슈
- closed: #100 

## 작업 내용
### 1. 프로필 이미지 전용 S3 서비스 구현 (`S3ImageService`)
- **AWS SDK v2 통합**: `S3Client`를 활용한 객체 업로드 및 삭제(Delete) 로직 구현.
- **비용 최적화**: 새로운 프로필 이미지 업로드 시, S3 스토리지 낭비를 방지하기 위해 기존에 저장된 S3 이미지를 자동으로 찾아 삭제하는 로직 추가.
- 보안 및 유효성 검사: 
  - 파일 용량 제한 (최대 5MB)
  - 허용 확장자 제한 (`jpg`, `jpeg`, `png`)
  - 파일명 중복(Overwrite) 방지를 위한 `UUID` 기반 고유 식별자 적용.
- 방어적 프로그래밍: 로컬(`dev`) 환경 테스트 편의성을 위해 `@PostConstruct`를 활용한 LocalStack 버킷(`aibe-bucket`) 자동 생성 로직 추가.

### 2. API 엔드포인트 구축 (`MemberController` & `MemberService`)
- `PATCH /api/v1/mypage/profile/image` 엔드포인트 추가.
- `multipart/form-data` 형식의 파일을 처리하기 위해 `@RequestPart` 적용.
- 트랜잭션(`@Transactional`) 내에서 '기존 이미지 삭제 -> 새 이미지 업로드 -> DB 엔티티 갱신' 흐름이 원활하게 동작하도록 서비스 로직 구성.

### 3. 엔티티 및 테스트 환경 개선
- `Member` 엔티티에 프로필 이미지만 단독으로 업데이트하는 `updateProfileImage()` 도메인 메서드 추가 (책임 분리).
- `DataInitializer` 수정: 더미 데이터 생성 시 필드 누락(Role, Provider)으로 인한 NPE 오류 수정 및 원활한 통합 테스트 환경 보장.

<br/>

## 변경 사항 및 주의 사항
- HTTP 헤더의 `Content-Type`을 반드시 `multipart.form-data`로 설정해야 하며, 파일에 담긴 파라미터 Key 이름은 `file`로 맞춰서 요청해야 서버에서 인식 가능
- 업로드 용량(5MB), 확장자(`jpg`, `jpeg`, `png`)만 허용. 다른 포맷 업로드 시 예외 처

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
