### PR TITLE
[FIX] Datainitializer.java 관련 빌드 오류 해결

### DIFF
--- a/src/main/java/com/aibe/team2/global/init/DataInitializer.java
+++ b/src/main/java/com/aibe/team2/global/init/DataInitializer.java
@@ -1,6 +1,7 @@
 package com.aibe.team2.global.init;
 
 import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.enums.InterviewMode;
 import com.aibe.team2.domain.interview.repository.InterviewRepository;
 import com.aibe.team2.domain.jobposting.entity.JobPosting;
 import com.aibe.team2.domain.jobposting.repository.JobPostingRepository;
@@ -74,8 +75,10 @@ public class DataInitializer implements CommandLineRunner {
                // 4-1. InterviewSession
                InterviewSession session = InterviewSession.builder()
                        .memberId(member.getMemberId())
+                       .interviewMode(i % 3 == 0 ? InterviewMode.STRESS : (i % 3 == 1 ? InterviewMode.FOLLOW_UP : InterviewMode.NORMAL)) // 필수 필드 추가
                        .interviewType(i % 2 == 0 ? "TEXT" : "VOICE") // 변경된 필드명에 맞게 수정
-                       .aiProvider(i % 2 == 0 ? "OPEN_AI" : "RETELL") // aiProvider 값도 함께 세팅 (Null 방지)
+                       .aiProvider(i % 2 == 0 ? "GEMINI" : "RETELL") // aiProvider 값도 함께 세팅 (Null 방지)
+                       .modelVariant("gemini-flash-latest")          // AI 엔진 파트이므로 함께 세팅
                        .build();
 
                setCreatedAt(session, pastDate);


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 데이터 초기화 로직 수정: DataInitializer에서 InterviewSession 더미 데이터를 생성할 때 필수 필드인 interviewMode가 누락되어 발생하던 SQL NULL 제약 조건 위반 에러 해결
- AI 엔진 스펙 최신화: 초기 데이터 생성 시 aiProvider를 OPEN_AI에서 현재 프로젝트 표준인 GEMINI로 변경하고, modelVariant 필드(gemini-flash-latest) 추가
<br/>

## 변경 사항 및 주의 사항
- 엔티티 변경 사항 반영: 최근 InterviewSession 엔티티의 리팩토링으로 인해 interviewMode 필드가 String에서 Enum으로 변경되고 nullable = false 설정이 추가되었습니다. 이에 따라 더미 데이터 생성부에서도 반드시 InterviewMode 값을 할당하도록 수정
- 패키지 임포트: com.aibe.team2.domain.interview.enums.InterviewMode가 추가됨
<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [ ] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #
