### PR TITLE
[FEAT] AI 면접(텍스트) 세션 상태 흐름 구현 (FR-INT-02)

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -4,6 +4,8 @@ import com.aibe.team2.domain.interview.dto.InterviewStartRequest;
 import com.aibe.team2.domain.interview.dto.VoiceSessionResponse;
 import com.aibe.team2.domain.interview.entity.InterviewSession;
 import com.aibe.team2.domain.interview.enums.InterviewMode;
+import com.aibe.team2.domain.interview.enums.InterviewSessionStatus;
+import com.aibe.team2.domain.interview.repository.InterviewRepository;
 import com.aibe.team2.domain.interview.service.ConversationManager;
 import com.aibe.team2.domain.interview.service.InterviewManager;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +23,12 @@ public class InterviewController {
 
     private final ConversationManager conversationManager;
     private final InterviewManager interviewManager;
+    private final InterviewRepository interviewRepository; // 세션 조회 및 상태 확인용 리포지토리 의존성 추가
 
     @PostMapping("/start")
     public ResponseEntity<InterviewSession> startInterview(@RequestBody InterviewStartRequest request) {
         try {
-            // 리뷰 반영: valueOf() 대신 안전한 from() 메서드 사용
+            // 안전한 from() 메서드 사용
             InterviewSession session = interviewManager.startInterview(
                     request.getMemberId(),
                     request.getResumeId(),
@@ -35,9 +38,8 @@ public class InterviewController {
                     request.getAiProvider(),
                     request.getModelVariant()
             );
-            return ResponseEntity.ok(session);
+            return ResponseEntity.ok(session); // 초기 생성 시 상태는 내부적으로 CREATED
         } catch (IllegalArgumentException e) {
-            // 유효하지 않은 입력 시 400 Bad Request 에러 응답
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
     }
@@ -46,8 +48,23 @@ public class InterviewController {
     public SseEmitter streamTextInterview(
             @PathVariable Long sessionId,
             @RequestParam String answer,
+            @RequestParam Long memberId, // 프론트엔드에서 넘긴 memberId 받기
             @RequestParam(required = false, defaultValue = "gemini-flash-latest") String modelVariant,
             @RequestParam(required = false, defaultValue = "NORMAL") String interviewMode) {
+
+        // 1. 세션 존재 여부 확인
+        InterviewSession session = interviewRepository.findById(sessionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "면접 세션을 찾을 수 없습니다."));
+
+        // 2. 보안: 소유권 검증 (IDOR 방어) - 다른 사람의 세션 스트리밍 훔쳐보기 방지
+        if (!session.getMemberId().equals(memberId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 면접 세션에 접근할 권한이 없습니다.");
+        }
+
+        // 3. [FR-INT-02] 상태 전이: 생성된 세션이 처음 호출될 때 IN_PROGRESS 로 변경
+        if (session.getStatus() == InterviewSessionStatus.CREATED) {
+            interviewManager.advanceStatus(sessionId, InterviewSessionStatus.IN_PROGRESS);
+        }
 
         SseEmitter emitter = new SseEmitter(120000L);
 
@@ -56,7 +73,7 @@ public class InterviewController {
                     sessionId,
                     answer,
                     modelVariant,
-                    InterviewMode.from(interviewMode), // 안전한 파싱 적용
+                    InterviewMode.from(interviewMode), // 안전한 파싱
                     emitter
             );
         } catch (IllegalArgumentException e) {
@@ -67,7 +84,40 @@ public class InterviewController {
     }
 
     @PostMapping("/{sessionId}/voice/start")
-    public VoiceSessionResponse startVoiceInterview(@PathVariable Long sessionId) {
+    public VoiceSessionResponse startVoiceInterview(
+            @PathVariable Long sessionId,
+            @RequestParam Long memberId) { // 프론트엔드 연동용 memberId
+
+        InterviewSession session = interviewRepository.findById(sessionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "면접 세션을 찾을 수 없습니다."));
+
+        // 보안: 음성 통화 역시 소유권 철저히 검증
+        if (!session.getMemberId().equals(memberId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 면접 세션에 접근할 권한이 없습니다.");
+        }
+
+        // [FR-INT-02] 상태 전이: 음성 세션 시작 시 IN_PROGRESS 로 변경
+        if (session.getStatus() == InterviewSessionStatus.CREATED) {
+            interviewManager.advanceStatus(sessionId, InterviewSessionStatus.IN_PROGRESS);
+        }
+
         return conversationManager.startVoiceInterview(sessionId);
+    }
+
+    @PatchMapping("/{sessionId}/end")
+    public ResponseEntity<Void> endInterview(
+            @PathVariable Long sessionId,
+            @RequestParam Long memberId) {
+
+        InterviewSession session = interviewRepository.findById(sessionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "면접 세션을 찾을 수 없습니다."));
+
+        if (!session.getMemberId().equals(memberId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 면접 세션에 접근할 권한이 없습니다.");
+        }
+
+        // 상태 전이: 면접 종료 시 DONE 으로 변경
+        interviewManager.advanceStatus(sessionId, InterviewSessionStatus.DONE);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
@@ -3,6 +3,7 @@ package com.aibe.team2.domain.interview.service;
 import com.aibe.team2.domain.interview.dto.InterviewRequestDto;
 import com.aibe.team2.domain.interview.dto.VoiceSessionResponse;
 import com.aibe.team2.domain.interview.enums.InterviewMode;
+import com.aibe.team2.domain.interview.enums.InterviewSessionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -14,8 +15,9 @@ public class ConversationManager {
 
     private final GeminiService geminiService;
     private final RetellService retellService;
+    private final InterviewManager interviewManager; // 추가: 상태 변경을 위한 Manager 주입
 
-    // @DistributedLock(key = "text-streaming", waitTime = 1, leaseTime = 20)
+    // @DistributedLock(key = "text-streaming", waitTime = 1, leaseTime = 20) <- 추후 분산 락 구현시 주석 해제
     public void startTextStreaming(Long sessionId, String answer, String modelVariant, InterviewMode interviewMode, SseEmitter emitter) {
         InterviewRequestDto request = new InterviewRequestDto(answer, modelVariant, interviewMode);
 
@@ -27,7 +29,11 @@ public class ConversationManager {
                         emitter.completeWithError(e);
                     }
                 },
-                error -> emitter.completeWithError(error),
+                error -> {
+                    // 추가: 스트리밍 중 에러 발생 시 세션을 ABORTED 상태로 전환
+                    interviewManager.advanceStatus(sessionId, InterviewSessionStatus.ABORTED);
+                    emitter.completeWithError(error);
+                },
                 emitter::complete
         );
     }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -88,7 +88,7 @@
     let currentType = 'TEXT';
     let textSessionId = null;
 
-    // 리뷰 반영: 소유권 검증을 위한 현재 사용자 ID (백엔드 보안 로직과 연동)
+    // 소유권 검증을 위한 현재 사용자 ID
     const MEMBER_ID = 1;
 
     const typeTextBtn = document.getElementById('typeText');
@@ -159,7 +159,9 @@
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        memberId: MEMBER_ID, // 소유권 검증용 ID 전달
+                        memberId: MEMBER_ID,
+                        jobPostingId: 1, // DB 에러 우회를 위한 더미 값
+                        resumeId: 1,     // 추가: resume_id NOT NULL DB 에러 우회용 더미 이력서 ID
                         interviewType: 'TEXT',
                         aiProvider: 'GEMINI',
                         interviewMode: modeSelect.value,
@@ -172,7 +174,7 @@
 
             const aiMsgDiv = appendMessage('ai', '');
 
-            // 리뷰 반영: SSE 스트리밍 시 memberId 파라미터 추가 (Ownership Check)
+            // SSE 스트리밍 시 memberId 파라미터 추가
             const url = `/api/interviews/${textSessionId}/text/stream?answer=${encodeURIComponent(text)}&modelVariant=${modelSelect.value}&interviewMode=${modeSelect.value}&memberId=${MEMBER_ID}`;
             const eventSource = new EventSource(url);
 
@@ -195,7 +197,6 @@
                 chatBox.scrollTop = chatBox.scrollHeight;
             };
 
-            // 🚀 리뷰 반영: SSE 통신 에러 로깅 복구
             eventSource.onerror = (err) => {
                 console.error("SSE 스트리밍 중 에러 발생:", err);
                 eventSource.close();
@@ -203,7 +204,6 @@
             };
 
         } catch (error) {
-            // 🚀 리뷰 반영: API 호출 실패 에러 로깅 복구
             console.error("텍스트 면접 시작 또는 데이터 전송 실패:", error);
             alert("텍스트 서버 연결 실패");
             sendBtn.disabled = false;
@@ -221,7 +221,9 @@
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
-                    memberId: MEMBER_ID, // 소유권 검증용 ID 전달
+                    memberId: MEMBER_ID,
+                    jobPostingId: 1, // DB 에러 우회를 위한 더미 값
+                    resumeId: 1,     // 추가: resume_id NOT NULL DB 에러 우회용 더미 이력서 ID
                     interviewType: 'VOICE',
                     aiProvider: 'RETELL',
                     interviewMode: 'NORMAL'
@@ -229,7 +231,7 @@
             });
             const session = await response.json();
 
-            // 리뷰 반영: 음성 면접 시작 시 memberId 파라미터 추가 (Ownership Check)
+            // Retell 토큰 발급 요청
             const voiceRes = await fetch(`/api/interviews/${session.id}/voice/start?memberId=${MEMBER_ID}`, { method: 'POST' });
             const voiceData = await voiceRes.json();
 
@@ -240,7 +242,6 @@
             stopVoiceBtn.disabled = false;
 
         } catch (err) {
-            // 리뷰 반영: 에러 로깅 복구
             console.error("음성 대화 시작 실패:", err);
             alert("음성 연결에 실패했습니다.");
             startVoiceBtn.disabled = false;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -23,10 +23,10 @@
         input[type="text"] { flex: 1; padding: 12px; border: 1px solid #ced4da; border-radius: 8px; outline: none; }
         .action-btn { padding: 12px 20px; background: #28a745; color: white; border: none; border-radius: 8px; cursor: pointer; font-weight: bold; transition: 0.2s; }
         .action-btn:disabled { background: #adb5bd; cursor: not-allowed; }
+        .stop-btn { background: #dc3545; }
         #voiceArea { display: none; padding: 30px 20px; border: 2px dashed #dee2e6; border-radius: 12px; background: #fdfdfd; }
         .voice-status { font-weight: bold; margin-bottom: 25px; color: #333; font-size: 16px; }
         .voice-controls { display: flex; justify-content: center; gap: 10px; }
-        .stop-btn { background: #dc3545; }
         #voiceSubtitle { margin-top: 25px; padding: 15px; background: #e9ecef; border-radius: 8px; height: 200px; overflow-y: auto; text-align: left; font-size: 15px; display: none; flex-direction: column; gap: 10px; box-shadow: inset 0 2px 4px rgba(0,0,0,0.05); }
         .stt-line { line-height: 1.4; padding: 8px; border-radius: 6px; background: white; }
     </style>
@@ -69,6 +69,8 @@
             <input type="text" id="userInput" placeholder="답변을 입력하세요..." autocomplete="off">
             <button class="action-btn" id="sendBtn">전송</button>
         </div>
+        <!-- 🚀 [FR-INT-02] 텍스트 면접 종료용 버튼 추가 -->
+        <button class="action-btn stop-btn" id="endTextBtn" style="width: 100%; margin-top: 15px; display: none;">🛑 텍스트 면접 종료 및 결과 제출</button>
     </div>
 
     <div id="voiceArea">
@@ -86,10 +88,14 @@
 
     const retellWebClient = new RetellWebClient();
     let currentType = 'TEXT';
-    let textSessionId = null;
 
-    // 소유권 검증을 위한 현재 사용자 ID
-    const MEMBER_ID = 1;
+    // 🚀 세션 관리를 위한 변수 선언
+    let textSessionId = null;
+    let voiceSessionId = null;
+
+    const MEMBER_ID = 1; // 소유권 검증용 유저 ID
+    const RESUME_ID = 1; // Null 제약 우회용
+    const JOB_POSTING_ID = 1; // Null 제약 우회용
 
     const typeTextBtn = document.getElementById('typeText');
     const typeVoiceBtn = document.getElementById('typeVoice');
@@ -97,6 +103,7 @@
     const voiceArea = document.getElementById('voiceArea');
     const chatBox = document.getElementById('chatBox');
     const sendBtn = document.getElementById('sendBtn');
+    const endTextBtn = document.getElementById('endTextBtn'); // 텍스트 종료 버튼
     const startVoiceBtn = document.getElementById('startVoiceBtn');
     const stopVoiceBtn = document.getElementById('stopVoiceBtn');
     const voiceSubtitle = document.getElementById('voiceSubtitle');
@@ -121,7 +128,7 @@
     });
 
     retellWebClient.on("call_ended", () => {
-        document.getElementById('voiceStatus').innerText = "✅ 대화가 종료되었습니다.";
+        document.getElementById('voiceStatus').innerText = "✅ 대화가 종료되었습니다. (상태: DONE)";
         startVoiceBtn.disabled = false;
         stopVoiceBtn.disabled = true;
     });
@@ -160,8 +167,8 @@
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         memberId: MEMBER_ID,
-                        jobPostingId: 1, // DB 에러 우회를 위한 더미 값
-                        resumeId: 1,     // 추가: resume_id NOT NULL DB 에러 우회용 더미 이력서 ID
+                        jobPostingId: JOB_POSTING_ID,
+                        resumeId: RESUME_ID,
                         interviewType: 'TEXT',
                         aiProvider: 'GEMINI',
                         interviewMode: modeSelect.value,
@@ -170,11 +177,12 @@
                 });
                 const session = await response.json();
                 textSessionId = session.id;
+
+                // 첫 질문이 시작되면 종료 버튼 노출
+                endTextBtn.style.display = 'block';
             }
 
             const aiMsgDiv = appendMessage('ai', '');
-
-            // SSE 스트리밍 시 memberId 파라미터 추가
             const url = `/api/interviews/${textSessionId}/text/stream?answer=${encodeURIComponent(text)}&modelVariant=${modelSelect.value}&interviewMode=${modeSelect.value}&memberId=${MEMBER_ID}`;
             const eventSource = new EventSource(url);
 
@@ -198,15 +206,42 @@
             };
 
             eventSource.onerror = (err) => {
-                console.error("SSE 스트리밍 중 에러 발생:", err);
+                console.error("SSE 스트리밍 에러:", err);
                 eventSource.close();
                 sendBtn.disabled = false;
             };
 
         } catch (error) {
-            console.error("텍스트 면접 시작 또는 데이터 전송 실패:", error);
-            alert("텍스트 서버 연결 실패");
+            console.error("데이터 전송 실패:", error);
+            alert("서버 연결 실패");
             sendBtn.disabled = false;
+        }
+    };
+
+    // 🚀 [FR-INT-02] 텍스트 면접 종료 로직 (PATCH /end 호출)
+    endTextBtn.onclick = async () => {
+        if (!textSessionId) return;
+        if (!confirm("면접을 완전히 종료하시겠습니까?\n종료 후에는 리포트가 생성됩니다.")) return;
+
+        try {
+            endTextBtn.disabled = true;
+            sendBtn.disabled = true;
+            document.getElementById('userInput').disabled = true;
+
+            const response = await fetch(`/api/interviews/${textSessionId}/end?memberId=${MEMBER_ID}`, {
+                method: 'PATCH'
+            });
+
+            if (response.ok) {
+                alert("면접이 성공적으로 종료되었습니다. (상태: DONE)");
+                appendMessage('ai', '고생하셨습니다. 면접이 모두 종료되었으며 결과가 곧 산출됩니다.');
+            } else {
+                throw new Error("종료 처리 실패");
+            }
+        } catch (err) {
+            console.error("종료 처리 중 오류:", err);
+            alert("면접 종료 처리에 실패했습니다.");
+            endTextBtn.disabled = false;
         }
     };
 
@@ -222,17 +257,17 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     memberId: MEMBER_ID,
-                    jobPostingId: 1, // DB 에러 우회를 위한 더미 값
-                    resumeId: 1,     // 추가: resume_id NOT NULL DB 에러 우회용 더미 이력서 ID
+                    jobPostingId: JOB_POSTING_ID,
+                    resumeId: RESUME_ID,
                     interviewType: 'VOICE',
                     aiProvider: 'RETELL',
                     interviewMode: 'NORMAL'
                 })
             });
             const session = await response.json();
+            voiceSessionId = session.id; // 🚀 음성 세션 ID 보관
 
-            // Retell 토큰 발급 요청
-            const voiceRes = await fetch(`/api/interviews/${session.id}/voice/start?memberId=${MEMBER_ID}`, { method: 'POST' });
+            const voiceRes = await fetch(`/api/interviews/${voiceSessionId}/voice/start?memberId=${MEMBER_ID}`, { method: 'POST' });
             const voiceData = await voiceRes.json();
 
             document.getElementById('voiceStatus').innerText = "마이크 권한을 승인해 주세요...";
@@ -248,7 +283,22 @@
         }
     };
 
-    stopVoiceBtn.onclick = () => { retellWebClient.stopCall(); };
+    // 🚀 [FR-INT-02] 음성 대화 종료 시 PATCH /end 연동
+    stopVoiceBtn.onclick = async () => {
+        retellWebClient.stopCall();
+
+        if (voiceSessionId) {
+            try {
+                // 백엔드에 명시적으로 종료 상태(DONE) 전송
+                await fetch(`/api/interviews/${voiceSessionId}/end?memberId=${MEMBER_ID}`, {
+                    method: 'PATCH'
+                });
+                console.log("음성 세션 상태 DONE 변경 완료");
+            } catch(err) {
+                console.error("상태 변경 실패:", err);
+            }
+        }
+    };
 
     function appendMessage(sender, text) {
         const div = document.createElement('div');


### PR DESCRIPTION
## 관련 이슈
- closed: #117

## 작업 내용
AI 면접의 시작부터 종료, 예외 상황까지의 전 과정을 관리하는 세션 상태 시스템을 구축
- 상태 전환 로직 구현: - 면접 최초 연결 시 세션 상태를 IN_PROGRESS로 즉시 업데이트
- 면접 종료 API(PATCH /end)를 신규 개발하여 정상 종료 시 DONE 상태로 전환
- 예외 처리 및 통계 최적화: - 스트리밍 중 통신 장애 발생 시 상태를 ABORTED로 전환하여, 추후 데이터 분석 시 유효하지 않은 세션으로 분류되도록 처리
- 프론트엔드 연동: - index.html 내 종료 버튼 클릭 시 /end API가 호출되도록 연동 작업을 완료
<br/>

## 변경 사항 및 주의 사항
- API 신설: PATCH /api/v1/interview/end (세션 ID 필수)가 추가

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #
