### PR TITLE
[FIX] 프론트엔드 연동을 위한 글로벌 CORS 및 Security 설정 업데이트

### DIFF
--- a/src/main/java/com/aibe/team2/domain/mypage/dto/request/JobPreferenceUpdateRequest.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/request/JobPreferenceUpdateRequest.java
@@ -3,10 +3,12 @@ package com.aibe.team2.domain.mypage.dto.request;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JobPreferenceUpdateRequest {
     private List<String> targetJobRoles;

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/request/ProfileUpdate.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/request/ProfileUpdate.java
@@ -3,14 +3,13 @@ package com.aibe.team2.domain.mypage.dto.request;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProfileUpdate {
-
     private String nickname;
-
     private String profileImageUrl; // 제거 시 null 또는 빈 값 전송
-
     private JobPreferenceUpdateRequest jobPreferences;
 }

--- a/src/main/java/com/aibe/team2/global/config/SecurityConfig.java
+++ b/src/main/java/com/aibe/team2/global/config/SecurityConfig.java
@@ -9,7 +9,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -47,7 +46,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-                .cors(Customizer.withDefaults()) // CORS 설정 적용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 적용
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -107,9 +106,9 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-//        configuration.setAllowedOrigins(List.of("http://localhost:5173")); // CORS 설정
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+       configuration.setAllowedOrigins(List.of("http://localhost:5173")); // CORS 설정
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/aibe/team2/global/config/WebConfig.java
+++ b/src/main/java/com/aibe/team2/global/config/WebConfig.java
@@ -14,11 +14,15 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginMemberIdResolver loginMemberIdResolver;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**") // 모든 주소 허용
-                .allowedOrigins("*") // 모든 출처 허용 (개발용)
-                .allowedMethods("GET", "POST", "PUT", "DELETE");
+                .allowedOrigins("http://localhost:5173") // 모든 출처 허용 (개발용)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 
     @Override


### PR DESCRIPTION
## 작업 내용
**`SecurityConfig.java`**
- 교차 출처 리소스 공유(CORS, Cross-Origin Resource Sharing) 설정
    - setAllowedOrigins: 프론트엔드 주소(http://localhost:5173)를 허용하여 브라우저의 보안 차단 해결.
    - setAllowedMethods: PATCH(부분 수정), OPTIONS(예비 요청) 등 필수 HTTP 메서드 추가.
    - setAllowCredentials(true): 프론트엔드에서 보낸 쿠키나 인증 헤더를 서버가 수락하도록 허용.

- 인증 정책 및 경로 권한 설정
    - permitAll(): Swagger, 로그인, 마이페이지 일부 API 등 인증 없이 접근 가능한 경로 최신화.
    - 예외 처리(Exception Handling): 인증 실패 시 401 Unauthorized 에러 메시지를 JSON 형식으로 커스텀 반환하도록 수정.
   
**`WebConfig.java`**
- 글로벌 CORS 매핑
    - addCorsMappings: Security 설정과 별개로 MVC 인터셉터 단계에서도 동일한 CORS 정책을 적용하여 통신 안정성 이중 확보.
    - maxAge(3600): 브라우저가 Pre-flight(예비 요청) 결과를 1시간 동안 캐싱하게 하여 네트워크 성능 최적화.

- 인자 해석기(Argument Resolver) 등록
    - addArgumentResolvers: LoginMemberIdResolver를 등록하여 컨트롤러에서 @LoginMemberId와 같은 어노테이션으로 현재 로그인한 사용자 ID를 바로 주입받을 수 있도록 개선.

**`JobPreferenceUpdateRequest.java`, `ProfileUpdate.java`**
: 마이페이지 프로필 내 취업 선호도 수정 시, 프론트엔드에서 전달되는 JSON 데이터가 Spring Boot DTO 객체로 정상적으로 역직렬화 및 데이터 바인딩되도록 @Setter 추가

<br/>

## 변경 사항 및 주의 사항
- 통신 안정성을 위해 Spring Security의 Filter 레벨(`corsConfigurationSource`)과 Spring MVC의 Interceptor 레벨(`addCorsMappings`) 양쪽 모두 동일한 정책 적용
- 현재 로컬 개발용으로 Origin이 5173 포트로 고정되어 있음. 추후 클라우드 배포 시 이 부분은 실제 서비스 도메인으로 환경 변수 분리 및 업데이트 필요
- 백엔드 서버 8080포트 + 프론트엔드 서버 5173 포트 실행 후, Axios 설정 파일에 `withCredentials: true`가 포함되어 있는지, 로그인이나 마이페이지 API를 호출해 CORS 에러가 발생하지 않는지 체크 부탁드립니다.

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

