### PR TITLE
Feat/130 fr int 06 generate follow up questions

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -14,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -26,15 +28,17 @@ public class InterviewController {
     private final ConversationManager conversationManager;
     private final InterviewManager interviewManager;
     private final InterviewRepository interviewRepository;
-
-    // [FR-INT-08] 리포트 조회를 위한 서비스 의존성 추가
     private final InterviewReportService interviewReportService;
 
     @PostMapping("/start")
-    public ResponseEntity<InterviewSession> startInterview(@RequestBody InterviewStartRequest request) {
+    public ResponseEntity<InterviewSession> startInterview(
+            @RequestBody InterviewStartRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
         try {
+            Long authenticatedMemberId = (userDetails != null) ? getMemberIdFromUserDetails(userDetails) : request.getMemberId();
+
             InterviewSession session = interviewManager.startInterview(
-                    request.getMemberId(),
+                    authenticatedMemberId,
                     request.getResumeId(),
                     request.getJobPostingId(),
                     InterviewMode.from(request.getInterviewMode()),
@@ -52,12 +56,12 @@ public class InterviewController {
     public SseEmitter streamTextInterview(
             @PathVariable Long sessionId,
             @RequestParam String answer,
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long memberId, // 🚀 복구: 프론트엔드 연동 및 SSE 한계 우회용
             @RequestParam(required = false, defaultValue = "gemini-flash-latest") String modelVariant,
             @RequestParam(required = false, defaultValue = "NORMAL") String interviewMode) {
 
-        // 리뷰 반영: 전용 private 메서드로 조회 및 권한 검증 위임 (코드 중복 제거)
-        InterviewSession session = validateAndGetSessionOwnership(sessionId, memberId);
+        InterviewSession session = validateAndGetSessionOwnership(sessionId, userDetails, memberId);
 
         if (session.getStatus() == InterviewSessionStatus.CREATED) {
             interviewManager.advanceStatus(sessionId, InterviewSessionStatus.IN_PROGRESS);
@@ -65,7 +69,6 @@ public class InterviewController {
 
         SseEmitter emitter = new SseEmitter(120000L);
         try {
-            // 리뷰 반영: sessionId(Long) 대신 검증이 끝난 session 객체를 통째로 넘기도록 수정
             conversationManager.startTextStreaming(session, answer, modelVariant, InterviewMode.from(interviewMode), emitter);
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
@@ -76,10 +79,10 @@ public class InterviewController {
     @PostMapping("/{sessionId}/voice/start")
     public VoiceSessionResponse startVoiceInterview(
             @PathVariable Long sessionId,
-            @RequestParam Long memberId) {
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long memberId) { // 🚀 복구
 
-        // 리뷰 반영: 전용 private 메서드로 위임 (코드 중복 제거)
-        InterviewSession session = validateAndGetSessionOwnership(sessionId, memberId);
+        InterviewSession session = validateAndGetSessionOwnership(sessionId, userDetails, memberId);
 
         if (session.getStatus() == InterviewSessionStatus.CREATED) {
             interviewManager.advanceStatus(sessionId, InterviewSessionStatus.IN_PROGRESS);
@@ -91,36 +94,50 @@ public class InterviewController {
     @PatchMapping("/{sessionId}/end")
     public ResponseEntity<Void> endInterview(
             @PathVariable Long sessionId,
-            @RequestParam Long memberId) {
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long memberId) { // 🚀 복구
 
-        // 리뷰 반영: 전용 private 메서드로 위임 (코드 중복 제거)
-        validateAndGetSessionOwnership(sessionId, memberId);
+        validateAndGetSessionOwnership(sessionId, userDetails, memberId);
 
         interviewManager.advanceStatus(sessionId, InterviewSessionStatus.DONE);
         return ResponseEntity.ok().build();
     }
 
-    // [FR-INT-08] 면접 결과 리포트 조회 엔드포인트 추가
     @GetMapping("/{sessionId}/report")
     public ResponseEntity<InterviewReportResponse> getInterviewReport(
             @PathVariable Long sessionId,
-            @RequestParam Long memberId) {
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(required = false) Long memberId) { // 🚀 복구
 
-        // 1. 소유권 검증: 내 면접이 맞는지 확인 (IDOR 취약점 방어)
-        InterviewSession session = validateAndGetSessionOwnership(sessionId, memberId);
+        InterviewSession session = validateAndGetSessionOwnership(sessionId, userDetails, memberId);
 
         try {
-            // 2. 리포트 서비스 호출 (이 안에서 DONE 상태인지 검증)
             InterviewReportResponse report = interviewReportService.getReport(session);
             return ResponseEntity.ok(report);
         } catch (IllegalStateException e) {
-            // 상태가 DONE이 아닐 경우 403 Forbidden 에러 반환
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage());
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
         }
     }
 
-    //보안 리뷰 반영: IDOR 취약점 방지 및 중복 로직 제거를 위한 전용 검증 메서드 현재는 프론트엔드 연동을 위해 @RequestParam 으로 넘겨받은 memberId를 검증에 사용 중 / 추후 Spring Security 적용 시, 파라미터를 삭제하고 @AuthenticationPrincipal 또는 SecurityContext에서 추출한 실제 로그인 사용자의 ID로 authenticatedMemberId를 주입받도록 수정
-    private InterviewSession validateAndGetSessionOwnership(Long sessionId, Long authenticatedMemberId) {
+    /**
+     * 🚀 보안 리뷰 반영 및 SSE 우회: Security 인증 객체와 fallbackMemberId를 유연하게 처리
+     */
+    private InterviewSession validateAndGetSessionOwnership(Long sessionId, UserDetails userDetails, Long fallbackMemberId) {
+        Long authenticatedMemberId;
+
+        // 1. Security Context에 정보가 있으면 우선 사용
+        if (userDetails != null) {
+            authenticatedMemberId = getMemberIdFromUserDetails(userDetails);
+        }
+        // 2. EventSource(SSE) 헤더 누락 및 로컬 테스트 환경을 위해 파라미터 값으로 우회(Fallback) 허용
+        else if (fallbackMemberId != null) {
+            authenticatedMemberId = fallbackMemberId;
+        }
+        // 3. 둘 다 없으면 401 에러
+        else {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다.");
+        }
+
         InterviewSession session = interviewRepository.findById(sessionId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "면접 세션을 찾을 수 없습니다."));
 
@@ -129,5 +146,16 @@ public class InterviewController {
         }
 
         return session;
+    }
+
+    /**
+     * UserDetails에서 MemberId 추출을 돕는 유틸 메서드
+     */
+    private Long getMemberIdFromUserDetails(UserDetails userDetails) {
+        try {
+            return Long.valueOf(userDetails.getUsername());
+        } catch (NumberFormatException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "회원 식별자를 처리할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -1,5 +1,6 @@
 package com.aibe.team2.domain.interview.controller;
 
+import com.aibe.team2.domain.interview.dto.InterviewReportResponse;
 import com.aibe.team2.domain.interview.dto.InterviewStartRequest;
 import com.aibe.team2.domain.interview.dto.VoiceSessionResponse;
 import com.aibe.team2.domain.interview.entity.InterviewSession;
@@ -8,6 +9,7 @@ import com.aibe.team2.domain.interview.enums.InterviewSessionStatus;
 import com.aibe.team2.domain.interview.repository.InterviewRepository;
 import com.aibe.team2.domain.interview.service.ConversationManager;
 import com.aibe.team2.domain.interview.service.InterviewManager;
+import com.aibe.team2.domain.interview.service.InterviewReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -24,6 +26,9 @@ public class InterviewController {
     private final ConversationManager conversationManager;
     private final InterviewManager interviewManager;
     private final InterviewRepository interviewRepository;
+
+    // [FR-INT-08] 리포트 조회를 위한 서비스 의존성 추가
+    private final InterviewReportService interviewReportService;
 
     @PostMapping("/start")
     public ResponseEntity<InterviewSession> startInterview(@RequestBody InterviewStartRequest request) {
@@ -51,7 +56,7 @@ public class InterviewController {
             @RequestParam(required = false, defaultValue = "gemini-flash-latest") String modelVariant,
             @RequestParam(required = false, defaultValue = "NORMAL") String interviewMode) {
 
-        // 🚀 리뷰 반영: 전용 private 메서드로 조회 및 권한 검증 위임 (코드 중복 제거)
+        // 리뷰 반영: 전용 private 메서드로 조회 및 권한 검증 위임 (코드 중복 제거)
         InterviewSession session = validateAndGetSessionOwnership(sessionId, memberId);
 
         if (session.getStatus() == InterviewSessionStatus.CREATED) {
@@ -60,7 +65,7 @@ public class InterviewController {
 
         SseEmitter emitter = new SseEmitter(120000L);
         try {
-            // 🚀 리뷰 반영: sessionId(Long) 대신 검증이 끝난 session 객체를 통째로 넘기도록 수정
+            // 리뷰 반영: sessionId(Long) 대신 검증이 끝난 session 객체를 통째로 넘기도록 수정
             conversationManager.startTextStreaming(session, answer, modelVariant, InterviewMode.from(interviewMode), emitter);
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
@@ -73,7 +78,7 @@ public class InterviewController {
             @PathVariable Long sessionId,
             @RequestParam Long memberId) {
 
-        // 🚀 리뷰 반영: 전용 private 메서드로 위임 (코드 중복 제거)
+        // 리뷰 반영: 전용 private 메서드로 위임 (코드 중복 제거)
         InterviewSession session = validateAndGetSessionOwnership(sessionId, memberId);
 
         if (session.getStatus() == InterviewSessionStatus.CREATED) {
@@ -88,21 +93,33 @@ public class InterviewController {
             @PathVariable Long sessionId,
             @RequestParam Long memberId) {
 
-        // 🚀 리뷰 반영: 전용 private 메서드로 위임 (코드 중복 제거)
+        // 리뷰 반영: 전용 private 메서드로 위임 (코드 중복 제거)
         validateAndGetSessionOwnership(sessionId, memberId);
 
         interviewManager.advanceStatus(sessionId, InterviewSessionStatus.DONE);
         return ResponseEntity.ok().build();
     }
 
-    /**
-     * 🚀 보안 리뷰 반영: IDOR 취약점 방지 및 중복 로직 제거를 위한 전용 검증 메서드
-     *
-     * TODO (gudals2040 팀원 리뷰 반영):
-     * 현재는 프론트엔드 연동을 위해 @RequestParam 으로 넘겨받은 memberId를 검증에 사용 중입니다.
-     * 추후 Spring Security 적용 시, 파라미터를 삭제하고 @AuthenticationPrincipal 또는 SecurityContext에서
-     * 추출한 실제 로그인 사용자의 ID로 authenticatedMemberId를 주입받도록 수정해야 합니다.
-     */
+    // [FR-INT-08] 면접 결과 리포트 조회 엔드포인트 추가
+    @GetMapping("/{sessionId}/report")
+    public ResponseEntity<InterviewReportResponse> getInterviewReport(
+            @PathVariable Long sessionId,
+            @RequestParam Long memberId) {
+
+        // 1. 소유권 검증: 내 면접이 맞는지 확인 (IDOR 취약점 방어)
+        InterviewSession session = validateAndGetSessionOwnership(sessionId, memberId);
+
+        try {
+            // 2. 리포트 서비스 호출 (이 안에서 DONE 상태인지 검증)
+            InterviewReportResponse report = interviewReportService.getReport(session);
+            return ResponseEntity.ok(report);
+        } catch (IllegalStateException e) {
+            // 상태가 DONE이 아닐 경우 403 Forbidden 에러 반환
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, e.getMessage());
+        }
+    }
+
+    //보안 리뷰 반영: IDOR 취약점 방지 및 중복 로직 제거를 위한 전용 검증 메서드 현재는 프론트엔드 연동을 위해 @RequestParam 으로 넘겨받은 memberId를 검증에 사용 중 / 추후 Spring Security 적용 시, 파라미터를 삭제하고 @AuthenticationPrincipal 또는 SecurityContext에서 추출한 실제 로그인 사용자의 ID로 authenticatedMemberId를 주입받도록 수정
     private InterviewSession validateAndGetSessionOwnership(Long sessionId, Long authenticatedMemberId) {
         InterviewSession session = interviewRepository.findById(sessionId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "면접 세션을 찾을 수 없습니다."));

--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -23,7 +23,7 @@ public class InterviewController {
 
     private final ConversationManager conversationManager;
     private final InterviewManager interviewManager;
-    private final InterviewRepository interviewRepository; // 세션 조회를 위해 Repository 의존성 추가
+    private final InterviewRepository interviewRepository;
 
     @PostMapping("/start")
     public ResponseEntity<InterviewSession> startInterview(@RequestBody InterviewStartRequest request) {
@@ -47,32 +47,24 @@ public class InterviewController {
     public SseEmitter streamTextInterview(
             @PathVariable Long sessionId,
             @RequestParam String answer,
-            @RequestParam Long memberId, // 프론트엔드 연동용 로그인 유저 ID
+            @RequestParam Long memberId,
             @RequestParam(required = false, defaultValue = "gemini-flash-latest") String modelVariant,
             @RequestParam(required = false, defaultValue = "NORMAL") String interviewMode) {
 
-        // 리뷰 반영: 전용 private 메서드로 조회 및 권한 검증 위임 (코드 중복 제거 및 보안 강화)
+        // 🚀 리뷰 반영: 전용 private 메서드로 조회 및 권한 검증 위임 (코드 중복 제거)
         InterviewSession session = validateAndGetSessionOwnership(sessionId, memberId);
 
-        // [FR-INT-02] 상태 전이 로직
         if (session.getStatus() == InterviewSessionStatus.CREATED) {
             interviewManager.advanceStatus(sessionId, InterviewSessionStatus.IN_PROGRESS);
         }
 
         SseEmitter emitter = new SseEmitter(120000L);
-
         try {
-            conversationManager.startTextStreaming(
-                    sessionId,
-                    answer,
-                    modelVariant,
-                    InterviewMode.from(interviewMode),
-                    emitter
-            );
+            // 🚀 리뷰 반영: sessionId(Long) 대신 검증이 끝난 session 객체를 통째로 넘기도록 수정
+            conversationManager.startTextStreaming(session, answer, modelVariant, InterviewMode.from(interviewMode), emitter);
         } catch (IllegalArgumentException e) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
         }
-
         return emitter;
     }
 
@@ -81,7 +73,7 @@ public class InterviewController {
             @PathVariable Long sessionId,
             @RequestParam Long memberId) {
 
-        // 두 번째 리뷰 반영: startVoiceInterview 엔드포인트 역시 동일한 검증 위임
+        // 🚀 리뷰 반영: 전용 private 메서드로 위임 (코드 중복 제거)
         InterviewSession session = validateAndGetSessionOwnership(sessionId, memberId);
 
         if (session.getStatus() == InterviewSessionStatus.CREATED) {
@@ -96,16 +88,21 @@ public class InterviewController {
             @PathVariable Long sessionId,
             @RequestParam Long memberId) {
 
-        // 세 번째 리뷰 반영: 면접 종료 엔드포인트 역시 동일한 검증 위임
+        // 🚀 리뷰 반영: 전용 private 메서드로 위임 (코드 중복 제거)
         validateAndGetSessionOwnership(sessionId, memberId);
 
         interviewManager.advanceStatus(sessionId, InterviewSessionStatus.DONE);
         return ResponseEntity.ok().build();
     }
 
-    // 보안 리뷰 및 팀원 피드백 반영: IDOR 취약점 방지 및 중복 로직 제거를 위한 전용 검증 메서드 (streamTextInterview, startVoiceInterview, endInterview 모든 엔드포인트에 공통 적용됨)
-     // 현재는 프론트엔드 연동을 위해 @RequestParam 으로 넘겨받은 memberId를 검증에 사용 중
-     // 추후 Spring Security 적용 시, 컨트롤러 파라미터를 삭제하고 @AuthenticationPrincipal SecurityContext에서 추출한 실제 로그인 사용자의 ID로 변경하여 완벽한 인가 처리를 수행
+    /**
+     * 🚀 보안 리뷰 반영: IDOR 취약점 방지 및 중복 로직 제거를 위한 전용 검증 메서드
+     *
+     * TODO (gudals2040 팀원 리뷰 반영):
+     * 현재는 프론트엔드 연동을 위해 @RequestParam 으로 넘겨받은 memberId를 검증에 사용 중입니다.
+     * 추후 Spring Security 적용 시, 파라미터를 삭제하고 @AuthenticationPrincipal 또는 SecurityContext에서
+     * 추출한 실제 로그인 사용자의 ID로 authenticatedMemberId를 주입받도록 수정해야 합니다.
+     */
     private InterviewSession validateAndGetSessionOwnership(Long sessionId, Long authenticatedMemberId) {
         InterviewSession session = interviewRepository.findById(sessionId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "면접 세션을 찾을 수 없습니다."));

--- a/src/main/java/com/aibe/team2/domain/interview/dto/InterviewReportResponse.java
+++ b/src/main/java/com/aibe/team2/domain/interview/dto/InterviewReportResponse.java
@@ -1,0 +1,37 @@
+package com.aibe.team2.domain.interview.dto;
+
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.enums.InterviewMode;
+import com.aibe.team2.domain.interview.enums.InterviewSessionStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InterviewReportResponse {
+    private Long sessionId;
+    private InterviewMode interviewMode;
+    private String interviewType;
+    private InterviewSessionStatus status;
+    private Integer finalScore;
+    private LocalDateTime createdAt;
+
+    // 연관된 이력서와 공고의 '제목'을 프론트엔드에 전달하기 위한 필드
+    private String resumeTitle;
+    private String jobTitle;
+
+    public static InterviewReportResponse of(InterviewSession session, String resumeTitle, String jobTitle) {
+        return InterviewReportResponse.builder()
+                .sessionId(session.getId())
+                .interviewMode(session.getInterviewMode())
+                .interviewType(session.getInterviewType())
+                .status(session.getStatus())
+                .finalScore(session.getFinalScore())
+                .createdAt(session.getCreatedAt())
+                .resumeTitle(resumeTitle)
+                .jobTitle(jobTitle)
+                .build();
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/interview/dto/InterviewRequestDto.java
+++ b/src/main/java/com/aibe/team2/domain/interview/dto/InterviewRequestDto.java
@@ -12,5 +12,8 @@ public class InterviewRequestDto {
     private String message;
     private String modelVariant;
     private InterviewMode interviewMode;
-    private String resumeContent; // [FR-INT-06] 프롬프트에 주입할 이력서 원문 데이터 추가
+
+    // [FR-INT-06, 07] 프롬프트에 동적 주입할 컨텍스트 데이터 필드 추가
+    private String resumeContent;
+    private String jobDescription;
 }

--- a/src/main/java/com/aibe/team2/domain/interview/dto/InterviewRequestDto.java
+++ b/src/main/java/com/aibe/team2/domain/interview/dto/InterviewRequestDto.java
@@ -12,4 +12,5 @@ public class InterviewRequestDto {
     private String message;
     private String modelVariant;
     private InterviewMode interviewMode;
+    private String resumeContent; // [FR-INT-06] 프롬프트에 주입할 이력서 원문 데이터 추가
 }

--- a/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
@@ -5,6 +5,8 @@ import com.aibe.team2.domain.interview.dto.VoiceSessionResponse;
 import com.aibe.team2.domain.interview.entity.InterviewSession;
 import com.aibe.team2.domain.interview.enums.InterviewMode;
 import com.aibe.team2.domain.interview.enums.InterviewSessionStatus;
+import com.aibe.team2.domain.jobposting.entity.JobPosting;
+import com.aibe.team2.domain.jobposting.repository.JobPostingRepository;
 import com.aibe.team2.domain.resume.entity.Resume;
 import com.aibe.team2.domain.resume.repository.ResumeRepository;
 import com.aibe.team2.global.redis.lock.DistributedLock;
@@ -21,8 +23,10 @@ public class ConversationManager {
 
     private final GeminiService geminiService;
     private final RetellService retellService;
-    private final InterviewManager interviewManager; // 추가: 상태 변경을 위한 Manager 주입
-    private final ResumeRepository resumeRepository; //  [FR-INT-06] 이력서 조회를 위한 의존성 추가
+    private final InterviewManager interviewManager; // 상태 변경을 위한 Manager 주입
+
+    private final ResumeRepository resumeRepository; // [FR-INT-06] 이력서 조회를 위한 의존성 추가
+    private final JobPostingRepository jobPostingRepository; //  [FR-INT-07] 채용 공고 조회를 위한 의존성 추가
 
     @DistributedLock(key = "text-streaming", waitTime = 1, leaseTime = 20)
     public void startTextStreaming(InterviewSession session, String answer, String modelVariant, InterviewMode interviewMode, SseEmitter emitter) {
@@ -35,8 +39,16 @@ public class ConversationManager {
                     .orElse(null); // 권한이 없거나 찾을 수 없으면 주입하지 않음
         }
 
-        // DTO 생성 시 추출한 이력서 데이터 포함
-        InterviewRequestDto request = new InterviewRequestDto(answer, modelVariant, interviewMode, resumeContent);
+        // [FR-INT-07] 채용 공고 내용 안전하게 조회 및 추출
+        String jobDescription = null;
+        if (session.getJobPostingId() != null) {
+            jobDescription = jobPostingRepository.findByIdAndMemberId(session.getJobPostingId(), session.getMemberId())
+                    .map(JobPosting::getJobDescription)
+                    .orElse(null);
+        }
+
+        // DTO 생성 시 추출한 이력서 및 공고 데이터 모두 포함
+        InterviewRequestDto request = new InterviewRequestDto(answer, modelVariant, interviewMode, resumeContent, jobDescription);
 
         geminiService.streamQuestion(String.valueOf(session.getId()), request).subscribe(
                 data -> {

--- a/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
@@ -2,13 +2,19 @@ package com.aibe.team2.domain.interview.service;
 
 import com.aibe.team2.domain.interview.dto.InterviewRequestDto;
 import com.aibe.team2.domain.interview.dto.VoiceSessionResponse;
+import com.aibe.team2.domain.interview.entity.InterviewSession;
 import com.aibe.team2.domain.interview.enums.InterviewMode;
 import com.aibe.team2.domain.interview.enums.InterviewSessionStatus;
+import com.aibe.team2.domain.resume.entity.Resume;
+import com.aibe.team2.domain.resume.repository.ResumeRepository;
+import com.aibe.team2.global.redis.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ConversationManager {
@@ -16,12 +22,23 @@ public class ConversationManager {
     private final GeminiService geminiService;
     private final RetellService retellService;
     private final InterviewManager interviewManager; // 추가: 상태 변경을 위한 Manager 주입
+    private final ResumeRepository resumeRepository; //  [FR-INT-06] 이력서 조회를 위한 의존성 추가
 
-    // @DistributedLock(key = "text-streaming", waitTime = 1, leaseTime = 20) <- 추후 분산 락 구현시 주석 해제
-    public void startTextStreaming(Long sessionId, String answer, String modelVariant, InterviewMode interviewMode, SseEmitter emitter) {
-        InterviewRequestDto request = new InterviewRequestDto(answer, modelVariant, interviewMode);
+    @DistributedLock(key = "text-streaming", waitTime = 1, leaseTime = 20)
+    public void startTextStreaming(InterviewSession session, String answer, String modelVariant, InterviewMode interviewMode, SseEmitter emitter) {
 
-        geminiService.streamQuestion(String.valueOf(sessionId), request).subscribe(
+        // [FR-INT-06] 자기소개서 내용 안전하게 조회 및 추출
+        String resumeContent = null;
+        if (session.getResumeId() != null) {
+            resumeContent = resumeRepository.findByIdAndMemberId(session.getResumeId(), session.getMemberId())
+                    .map(Resume::getContent)
+                    .orElse(null); // 권한이 없거나 찾을 수 없으면 주입하지 않음
+        }
+
+        // DTO 생성 시 추출한 이력서 데이터 포함
+        InterviewRequestDto request = new InterviewRequestDto(answer, modelVariant, interviewMode, resumeContent);
+
+        geminiService.streamQuestion(String.valueOf(session.getId()), request).subscribe(
                 data -> {
                     try {
                         emitter.send(SseEmitter.event().name("message").data(data));
@@ -30,8 +47,9 @@ public class ConversationManager {
                     }
                 },
                 error -> {
-                    // 추가: 스트리밍 중 에러 발생 시 세션을 ABORTED 상태로 전환
-                    interviewManager.advanceStatus(sessionId, InterviewSessionStatus.ABORTED);
+                    log.error("스트리밍 중 에러 발생. 세션을 ABORTED 상태로 전환합니다. SessionID: {}", session.getId(), error);
+                    // 통계 제외를 위해 에러 발생 시 상태를 ABORTED로 변경
+                    interviewManager.advanceStatus(session.getId(), InterviewSessionStatus.ABORTED);
                     emitter.completeWithError(error);
                 },
                 emitter::complete

--- a/src/main/java/com/aibe/team2/domain/interview/service/GeminiService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/GeminiService.java
@@ -54,8 +54,15 @@ public class GeminiService {
             resumeContext = "\n\n[Candidate's Resume]\n다음은 지원자의 자기소개서 내용입니다. 이를 바탕으로 지원자의 경험을 묻는 꼬리 질문을 생성하세요.\n" + request.getResumeContent();
         }
 
-        String finalPrompt = String.format("%s%s\n\n%s\n\n[Candidate Answer]\n%s",
-                atmospherePrompt, resumeContext, constraints, request.getMessage());
+        // [FR-INT-07] 채용 공고 기반 맞춤형 질문 생성을 위한 컨텍스트 동적 주입
+        String jobContext = "";
+        if (request.getJobDescription() != null && !request.getJobDescription().isBlank()) {
+            jobContext = "\n\n[Job Posting Requirements]\n다음은 지원자가 지원한 채용 공고의 상세 내용(요구 역량 및 주요 업무)입니다. 이를 바탕으로 직무 적합성을 검증하는 질문을 생성하세요.\n" + request.getJobDescription();
+        }
+
+        // 최종 프롬프트 조립 (분위기 + 이력서 + 채용공고 + 제약조건 + 사용자 답변)
+        String finalPrompt = String.format("%s%s%s\n\n%s\n\n[Candidate Answer]\n%s",
+                atmospherePrompt, resumeContext, jobContext, constraints, request.getMessage());
 
         log.info("[Gemini-Streaming] Session: {}, Mode: {}", sessionId, request.getInterviewMode());
 

--- a/src/main/java/com/aibe/team2/domain/interview/service/GeminiService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/GeminiService.java
@@ -1,6 +1,7 @@
 package com.aibe.team2.domain.interview.service;
 
 import com.aibe.team2.domain.interview.dto.InterviewRequestDto;
+import com.aibe.team2.domain.interview.enums.InterviewMode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -13,6 +14,7 @@ import reactor.core.publisher.Flux;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -43,13 +45,19 @@ public class GeminiService {
 
         String fullUrl = String.format("%s/v1beta/models/%s:streamGenerateContent?alt=sse", rootUrl, model);
 
-        // interviewMode.name()을 파일명으로 사용하여 분위기 프롬프트 로드 (NORMAL, FOLLOW_UP, STRESS)
         String atmospherePrompt = loadPromptFile(request.getInterviewMode().name());
         String constraints = loadPromptFile("constraints");
-        String finalPrompt = String.format("%s\n\n%s\n\n[Candidate Answer]\n%s",
-                atmospherePrompt, constraints, request.getMessage());
 
-        log.info("[Gemini-Success] Session: {}, Mode: {}", sessionId, request.getInterviewMode());
+        // [FR-INT-06] 이력서 기반 꼬리 질문 생성을 위한 컨텍스트 동적 주입
+        String resumeContext = "";
+        if (request.getResumeContent() != null && !request.getResumeContent().isBlank()) {
+            resumeContext = "\n\n[Candidate's Resume]\n다음은 지원자의 자기소개서 내용입니다. 이를 바탕으로 지원자의 경험을 묻는 꼬리 질문을 생성하세요.\n" + request.getResumeContent();
+        }
+
+        String finalPrompt = String.format("%s%s\n\n%s\n\n[Candidate Answer]\n%s",
+                atmospherePrompt, resumeContext, constraints, request.getMessage());
+
+        log.info("[Gemini-Streaming] Session: {}, Mode: {}", sessionId, request.getInterviewMode());
 
         return webClient.post()
                 .uri(URI.create(fullUrl))
@@ -64,15 +72,31 @@ public class GeminiService {
                 .doOnError(e -> log.error("=== 🚨 Gemini API 호출 에러: {} ===", e.getMessage()));
     }
 
+    //보안 리뷰 반영 (Remediation): Path Traversal 방어를 위한 허용 목록(Allow-list) 검증
     private String loadPromptFile(String fileName) {
+        final String currentFileName = fileName;
+
+        // 허용 목록 검증: Enum 상수에 있거나 'constraints'인 경우만 허용
+        boolean isAllowed = Arrays.stream(InterviewMode.values())
+                .anyMatch(mode -> mode.name().equals(currentFileName)) || "constraints".equals(currentFileName);
+
+        String targetFileName = fileName;
+        if (!isAllowed) {
+            log.error("보안 위협: 허용되지 않은 파일 이름 접근 시도 - {}", fileName);
+            targetFileName = "NORMAL";
+        }
+
         try {
-            Resource resource = resourceLoader.getResource("classpath:prompts/" + fileName + ".txt");
-            if (!resource.exists()) resource = resourceLoader.getResource("classpath:prompts/NORMAL.txt");
+            Resource resource = resourceLoader.getResource("classpath:prompts/" + targetFileName + ".txt");
+            if (!resource.exists()) {
+                log.warn("프롬프트 파일이 존재하지 않아 기본 설정을 로드합니다: {}", targetFileName);
+                resource = resourceLoader.getResource("classpath:prompts/NORMAL.txt");
+            }
             return StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
         } catch (IOException e) {
-            // 리뷰 반영: 예외 발생 시 로그를 남겨 근본 원인 파악이 가능하도록 수정
-            log.error("Failed to load prompt file: {}", fileName, e);
-            return "전문 면접관으로서 지원자에게 질문을 던져주세요.";
+            // 리뷰 반영: 에러 로깅 시 실제 원인(e) 기록
+            log.error("❌ 프롬프트 파일 로드 실패 [파일명: {}]: ", targetFileName, e);
+            return "면접관으로서 질문을 생성하세요.";
         }
     }
 }

--- a/src/main/java/com/aibe/team2/domain/interview/service/GeminiService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/GeminiService.java
@@ -60,26 +60,38 @@ public class GeminiService {
             jobContext = "\n\n[Job Posting Requirements]\n다음은 지원자가 지원한 채용 공고의 상세 내용(요구 역량 및 주요 업무)입니다. 이를 바탕으로 직무 적합성을 검증하는 질문을 생성하세요.\n" + request.getJobDescription();
         }
 
-        // 최종 프롬프트 조립 (분위기 + 이력서 + 채용공고 + 제약조건 + 사용자 답변)
-        String finalPrompt = String.format("%s%s%s\n\n%s\n\n[Candidate Answer]\n%s",
-                atmospherePrompt, resumeContext, jobContext, constraints, request.getMessage());
+        // 🚀 보안 리뷰 반영 (Prompt Injection 방어):
+        // 1. AI가 절대적으로 따라야 할 시스템 지시사항 (분위기, 이력서, 공고, 제약조건)
+        String systemPrompt = String.format("%s%s%s\n\n%s",
+                atmospherePrompt, resumeContext, jobContext, constraints);
+
+        // 2. 순수한 사용자 입력값 분리
+        String userMessage = request.getMessage();
 
         log.info("[Gemini-Streaming] Session: {}, Mode: {}", sessionId, request.getInterviewMode());
+
+        // 🚀 JSON Payload 조립 시 systemInstruction 속성을 명시적으로 분리하여 전송
+        Map<String, Object> requestBody = Map.of(
+                "systemInstruction", Map.of(
+                        "parts", List.of(Map.of("text", systemPrompt))
+                ),
+                "contents", List.of(
+                        Map.of("role", "user",
+                                "parts", List.of(Map.of("text", userMessage)))
+                )
+        );
 
         return webClient.post()
                 .uri(URI.create(fullUrl))
                 .header("x-goog-api-key", apiKey)
                 .header("Content-Type", "application/json")
-                .bodyValue(Map.of("contents", List.of(
-                        Map.of("role", "user",
-                                "parts", List.of(Map.of("text", finalPrompt)))
-                )))
+                .bodyValue(requestBody)
                 .retrieve()
                 .bodyToFlux(String.class)
                 .doOnError(e -> log.error("=== 🚨 Gemini API 호출 에러: {} ===", e.getMessage()));
     }
 
-    //보안 리뷰 반영 (Remediation): Path Traversal 방어를 위한 허용 목록(Allow-list) 검증
+    // Path Traversal 방어를 위한 허용 목록(Allow-list) 검증
     private String loadPromptFile(String fileName) {
         final String currentFileName = fileName;
 
@@ -101,7 +113,6 @@ public class GeminiService {
             }
             return StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
         } catch (IOException e) {
-            // 리뷰 반영: 에러 로깅 시 실제 원인(e) 기록
             log.error("❌ 프롬프트 파일 로드 실패 [파일명: {}]: ", targetFileName, e);
             return "면접관으로서 질문을 생성하세요.";
         }

--- a/src/main/java/com/aibe/team2/domain/interview/service/InterviewReportService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/InterviewReportService.java
@@ -1,0 +1,47 @@
+package com.aibe.team2.domain.interview.service;
+
+import com.aibe.team2.domain.interview.dto.InterviewReportResponse;
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.enums.InterviewSessionStatus;
+import com.aibe.team2.domain.jobposting.entity.JobPosting;
+import com.aibe.team2.domain.jobposting.repository.JobPostingRepository;
+import com.aibe.team2.domain.resume.entity.Resume;
+import com.aibe.team2.domain.resume.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InterviewReportService {
+
+    private final ResumeRepository resumeRepository;
+    private final JobPostingRepository jobPostingRepository;
+
+    public InterviewReportResponse getReport(InterviewSession session) {
+
+        // 🚀 [FR-INT-08] 핵심: DONE 상태 세션만 리포트 조회가 가능해야 한다.
+        if (session.getStatus() != InterviewSessionStatus.DONE) {
+            throw new IllegalStateException("면접이 정상적으로 완료된(DONE) 세션만 리포트를 조회할 수 있습니다. 현재 상태: " + session.getStatus());
+        }
+
+        // 이력서 제목 조회
+        String resumeTitle = null;
+        if (session.getResumeId() != null) {
+            resumeTitle = resumeRepository.findById(session.getResumeId())
+                    .map(Resume::getTitle)
+                    .orElse("삭제된 이력서");
+        }
+
+        // 채용 공고 제목 조회
+        String jobTitle = null;
+        if (session.getJobPostingId() != null) {
+            jobTitle = jobPostingRepository.findById(session.getJobPostingId())
+                    .map(JobPosting::getJobTitle)
+                    .orElse("삭제된 공고");
+        }
+
+        return InterviewReportResponse.of(session, resumeTitle, jobTitle);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/interview/service/InterviewReportService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/InterviewReportService.java
@@ -29,15 +29,14 @@ public class InterviewReportService {
         // 이력서 제목 조회
         String resumeTitle = null;
         if (session.getResumeId() != null) {
-            resumeTitle = resumeRepository.findById(session.getResumeId())
+            resumeTitle = resumeRepository.findByIdAndMemberId(session.getResumeId(), session.getMemberId())
                     .map(Resume::getTitle)
                     .orElse("삭제된 이력서");
         }
-
         // 채용 공고 제목 조회
         String jobTitle = null;
         if (session.getJobPostingId() != null) {
-            jobTitle = jobPostingRepository.findById(session.getJobPostingId())
+            jobTitle = jobPostingRepository.findByIdAndMemberId(session.getJobPostingId(), session.getMemberId())
                     .map(JobPosting::getJobTitle)
                     .orElse("삭제된 공고");
         }

--- a/src/main/java/com/aibe/team2/domain/jobposting/repository/JobPostingRepository.java
+++ b/src/main/java/com/aibe/team2/domain/jobposting/repository/JobPostingRepository.java
@@ -3,8 +3,13 @@ package com.aibe.team2.domain.jobposting.repository;
 import com.aibe.team2.domain.jobposting.entity.JobPosting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
+
     // 특정 유저의 공고를 등록일 기준 최신순으로 조회
     List<JobPosting> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    // [FR-INT-07] IDOR 방어: Id와 MemberId를 함께 검증하여 공고 조회 / 작성자 : 최원준
+    Optional<JobPosting> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -94,7 +94,7 @@
     let voiceSessionId = null;
 
     const MEMBER_ID = 1; // 소유권 검증용 유저 ID
-    const RESUME_ID = 1; // Null 제약 우회용
+    const RESUME_ID = 3;
     const JOB_POSTING_ID = 1; // Null 제약 우회용
 
     const typeTextBtn = document.getElementById('typeText');


### PR DESCRIPTION
## 관련 이슈
- closed: #130 
- closed: #132 
- closed: #133 

## 작업 내용
- [FR-INT-06, 07] AI 맞춤형 프롬프트 동적 주입
1. DB에서 사용자의 이력서(Resume) 내용과 채용 공고(Job Posting) 요구사항을 조회하여 Gemini 프롬프트 컨텍스트에 동적으로 주입하는 로직 구현.
2. 지원자의 경험을 검증하고 직무 적합성을 파악하는 날카로운 꼬리 질문 생성 파이프라인 완성.

- [FR-INT-08] 면접 결과 리포트 조회 API 구현
1. GET /api/interviews/{sessionId}/report 엔드포인트 및 InterviewReportResponse DTO 생성.
2. 세션 상태가 정상적으로 완료된(DONE) 경우에만 리포트 데이터를 반환하도록 비즈니스 검증 로직(InterviewReportService) 추가.

- 보안 강화 (IDOR 방어)
1. 세션 소유권 검증 로직을 validateAndGetSessionOwnership 전용 메서드로 분리하여, 타인의 면접 세션(스트리밍, 종료, 리포트 조회)에 접근할 수 없도록 권한 제어 적용.

<br/>

## 변경 사항 및 주의 사항
- Repository 조회 메서드 변경: 권한 없는 데이터 접근을 막기 위해 JobPostingRepository 및 ResumeRepository에서 데이터를 조회할 때 findByIdAndMemberId를 사용하도록 설계
- AI 프롬프트 흐름 변경: ConversationManager에서 이력서와 공고 내용을 추출한 뒤 InterviewRequestDto에 담아 GeminiService로 전달하도록 파라미터 구조가 변경됨
- 프론트엔드 연동 주의사항: 리포트 조회 API 호출 시, 해당 세션이 DONE 상태가 아니거나 본인의 세션이 아닐 경우 403 FORBIDDEN 에러를 반환. 프론트엔드 예외 처리 시 참고 바랍니다.

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #
