### PR TITLE
[FEAT] 마이페이지 면접 내역 조회 필터링/검색 추가 및 Redis 직렬화 설정 보완

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryCustom.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryCustom.java
@@ -1,13 +1,13 @@
 package com.aibe.team2.domain.interview.repository;
 
-import com.aibe.team2.domain.interview.enums.InterviewMode;
 import com.aibe.team2.domain.interview.enums.InterviewType;
 import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface InterviewSessionRepositoryCustom {
-    Page<InterviewSessionListResponse> findInterviewSessionList(
+    List<InterviewSessionListResponse> findInterviewSessionList(
             Long memberId,
             InterviewType type,
             String keyword,

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryCustom.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryCustom.java
@@ -1,9 +1,16 @@
 package com.aibe.team2.domain.interview.repository;
 
+import com.aibe.team2.domain.interview.enums.InterviewMode;
+import com.aibe.team2.domain.interview.enums.InterviewType;
 import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface InterviewSessionRepositoryCustom {
-    Page<InterviewSessionListResponse> findInterviewSessionList(Long memberId, Pageable pageable);
+    Page<InterviewSessionListResponse> findInterviewSessionList(
+            Long memberId,
+            InterviewType type,
+            String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
@@ -30,58 +30,35 @@ public class InterviewSessionRepositoryImpl implements InterviewSessionRepositor
             String keyword,
             Pageable pageable
     ) {
-
-        // 1. 실제 데이터 조회 쿼리
-        List<InterviewSessionListResponse> content = queryFactory
-                .select(Projections.constructor(InterviewSessionListResponse.class,
-                        interviewSession.id,
-                        resume.title,
-                        jobPosting.companyName,
-                        jobPosting.jobTitle,
-                        interviewSession.interviewMode,
-                        interviewSession.interviewType,
-                        interviewSession.status,
-                        interviewSession.finalScore,
-                        interviewSession.createdAt
-                ))
+        // 1. 공통 조건(from, join, where)을 포함하는 기본 쿼리 생성
+        JPAQuery<?> baseQuery = queryFactory
                 .from(interviewSession)
-                // [핵심] 엔티티에 연관관계가 없으므로 ON 절로 ID 값을 직접 매칭
                 .leftJoin(resume).on(interviewSession.resumeId.eq(resume.id))
                 .leftJoin(jobPosting).on(interviewSession.jobPostingId.eq(jobPosting.id))
-                .where(
-                        interviewSession.memberId.eq(memberId),
-                        eqType(type),              // 모드 필터 (VOICE, TEXT)
-                        containsKeyword(keyword)   // 검색어 필터
-                )
-                .orderBy(interviewSession.createdAt.desc()) // 최신순 정렬
-                .offset(pageable.getOffset())               // 페이징 시작점
-                .limit(pageable.getPageSize())              // 페이지 크기
-                .fetch();
-
-        // 2. 전체 개수 조회 쿼리
-        JPAQuery<Long> countQuery = queryFactory
-                .select(interviewSession.count())
-                .from(interviewSession)
-                // ✨ [수정됨] 검색어 필터링을 위해 JOIN이 필요하므로 카운트 쿼리에도 추가
-                .leftJoin(resume).on(interviewSession.resumeId.eq(resume.id))
-                .leftJoin(jobPosting).on(interviewSession.jobPostingId.eq(jobPosting.id))
-                // ✨ [수정됨] 데이터 쿼리와 완벽하게 동일한 조건 적용
                 .where(
                         interviewSession.memberId.eq(memberId),
                         eqType(type),
                         containsKeyword(keyword)
                 );
 
-        // 3. 데이터와 카운트 쿼리를 조합하여 Page 객체로 반환
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
-    }
+        // 2. 실제 데이터 조회 쿼리 (기본 쿼리를 복제한 후 select, orderBy, offset, limit 추가)
+        List<InterviewSessionListResponse> content = baseQuery.clone()
+                .select(Projections.constructor(InterviewSessionListResponse.class,
+                        interviewSession.id,
+                        resume.title,
+                        // ... 나머지 필드들 ...
+                        interviewSession.createdAt
+                ))
+                .orderBy(interviewSession.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
-    // 면접 모드(VOICE, TEXT) 일치 여부 확인
-    private BooleanExpression eqType(InterviewType type) {
-        if (type == null) {
-            return null; // 프론트에서 값이 안 오면(전체 조회 시) 조건을 무시
-        }
-        return interviewSession.interviewType.eq(type.name());
+        // 3. 전체 개수 조회 쿼리 (기본 쿼리를 복제한 후 count 추가)
+        JPAQuery<Long> countQuery = baseQuery.clone().select(interviewSession.count());
+
+        // 4. 결과 반환
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
     // 검색어 포함 여부 확인
@@ -92,5 +69,16 @@ public class InterviewSessionRepositoryImpl implements InterviewSessionRepositor
         // 예시: 회사명 또는 자기소개서 제목에 검색어가 포함되어 있는지 검사
         return jobPosting.companyName.contains(keyword)
                 .or(resume.title.contains(keyword));
+    }
+
+    private BooleanExpression eqType(InterviewType type) {
+        if (type == null) {
+            return null; // 프론트에서 값이 안 오면(전체 조회 시) 조건을 무시
+        }
+
+        // 1. 현재 엔티티의 필드가 String 타입이므로, Enum 객체를 String으로 변환(type.name())하여 비교합니다.
+        // 2. 나중을 위해 기술 부채(Technical Debt)를 기록해 둡니다.
+        // TODO: 향후 InterviewSession 엔티티의 interviewType 필드를 Enum으로 변경 후 eq(type)으로 리팩토링 필요
+        return interviewSession.interviewType.eq(type.name());
     }
 }

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.StringUtils;
@@ -24,7 +23,7 @@ public class InterviewSessionRepositoryImpl implements InterviewSessionRepositor
     private final JPAQueryFactory  queryFactory;
 
     @Override
-    public Page<InterviewSessionListResponse> findInterviewSessionList(
+    public List<InterviewSessionListResponse> findInterviewSessionList(
             Long memberId,
             InterviewType type,
             String keyword,
@@ -41,24 +40,23 @@ public class InterviewSessionRepositoryImpl implements InterviewSessionRepositor
                         containsKeyword(keyword)
                 );
 
-        // 2. 실제 데이터 조회 쿼리 (기본 쿼리를 복제한 후 select, orderBy, offset, limit 추가)
-        List<InterviewSessionListResponse> content = baseQuery.clone()
+        // 2. 실제 데이터 조회 쿼리 후 곧바로 List 반환
+        return baseQuery.clone()
                 .select(Projections.constructor(InterviewSessionListResponse.class,
                         interviewSession.id,
                         resume.title,
-                        // ... 나머지 필드들 ...
+                        jobPosting.companyName,
+                        jobPosting.jobTitle,
+                        interviewSession.interviewMode,
+                        interviewSession.interviewType,
+                        interviewSession.status,
+                        interviewSession.finalScore,
                         interviewSession.createdAt
                 ))
                 .orderBy(interviewSession.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .fetch();
-
-        // 3. 전체 개수 조회 쿼리 (기본 쿼리를 복제한 후 count 추가)
-        JPAQuery<Long> countQuery = baseQuery.clone().select(interviewSession.count());
-
-        // 4. 결과 반환
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+                .fetch(); // fetch()는 List를 반환합니다.
     }
 
     // 검색어 포함 여부 확인

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
@@ -1,13 +1,16 @@
 package com.aibe.team2.domain.interview.repository;
 
+import com.aibe.team2.domain.interview.enums.InterviewType;
 import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -21,7 +24,12 @@ public class InterviewSessionRepositoryImpl implements InterviewSessionRepositor
     private final JPAQueryFactory  queryFactory;
 
     @Override
-    public Page<InterviewSessionListResponse> findInterviewSessionList(Long memberId, Pageable pageable) {
+    public Page<InterviewSessionListResponse> findInterviewSessionList(
+            Long memberId,
+            InterviewType type,
+            String keyword,
+            Pageable pageable
+    ) {
 
         // 1. 실제 데이터 조회 쿼리
         List<InterviewSessionListResponse> content = queryFactory
@@ -40,7 +48,11 @@ public class InterviewSessionRepositoryImpl implements InterviewSessionRepositor
                 // [핵심] 엔티티에 연관관계가 없으므로 ON 절로 ID 값을 직접 매칭
                 .leftJoin(resume).on(interviewSession.resumeId.eq(resume.id))
                 .leftJoin(jobPosting).on(interviewSession.jobPostingId.eq(jobPosting.id))
-                .where(interviewSession.memberId.eq(memberId))
+                .where(
+                        interviewSession.memberId.eq(memberId),
+                        eqType(type),              // 모드 필터 (VOICE, TEXT)
+                        containsKeyword(keyword)   // 검색어 필터
+                )
                 .orderBy(interviewSession.createdAt.desc()) // 최신순 정렬
                 .offset(pageable.getOffset())               // 페이징 시작점
                 .limit(pageable.getPageSize())              // 페이지 크기
@@ -50,9 +62,35 @@ public class InterviewSessionRepositoryImpl implements InterviewSessionRepositor
         JPAQuery<Long> countQuery = queryFactory
                 .select(interviewSession.count())
                 .from(interviewSession)
-                .where(interviewSession.memberId.eq(memberId));
+                // ✨ [수정됨] 검색어 필터링을 위해 JOIN이 필요하므로 카운트 쿼리에도 추가
+                .leftJoin(resume).on(interviewSession.resumeId.eq(resume.id))
+                .leftJoin(jobPosting).on(interviewSession.jobPostingId.eq(jobPosting.id))
+                // ✨ [수정됨] 데이터 쿼리와 완벽하게 동일한 조건 적용
+                .where(
+                        interviewSession.memberId.eq(memberId),
+                        eqType(type),
+                        containsKeyword(keyword)
+                );
 
         // 3. 데이터와 카운트 쿼리를 조합하여 Page 객체로 반환
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    // 면접 모드(VOICE, TEXT) 일치 여부 확인
+    private BooleanExpression eqType(InterviewType type) {
+        if (type == null) {
+            return null; // 프론트에서 값이 안 오면(전체 조회 시) 조건을 무시
+        }
+        return interviewSession.interviewType.eq(type.name());
+    }
+
+    // 검색어 포함 여부 확인
+    private BooleanExpression containsKeyword(String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return null; // 검색어가 없으면 조건을 무시
+        }
+        // 예시: 회사명 또는 자기소개서 제목에 검색어가 포함되어 있는지 검사
+        return jobPosting.companyName.contains(keyword)
+                .or(resume.title.contains(keyword));
     }
 }

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
@@ -1,6 +1,6 @@
 package com.aibe.team2.domain.mypage.controller;
 
-import com.aibe.team2.domain.auth.dto.CustomUserDetails;
+import com.aibe.team2.domain.interview.enums.InterviewType;
 import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import com.aibe.team2.domain.mypage.service.MypageInterviewService;
 import com.aibe.team2.global.common.annotation.LoginMemberId;
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,10 +27,13 @@ public class MypageInterviewController {
     public ResponseEntity<Page<InterviewSessionListResponse>> getInterviewSessionList(
             @LoginMemberId Long memberId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(name = "mode", required = false) InterviewType type,
+            @RequestParam(required = false) String keyword
     ) {
         Pageable pageRequest = PageRequest.of(page, size);
-        Page<InterviewSessionListResponse> response = mypageInterviewService.getInterviewSessionList(memberId, pageRequest);
+        Page<InterviewSessionListResponse> response =
+                mypageInterviewService.getInterviewSessionList(memberId, type, keyword, pageRequest);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
@@ -28,7 +28,7 @@ public class MypageInterviewController {
             @LoginMemberId Long memberId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(name = "mode", required = false) InterviewType type,
+            @RequestParam(name = "type", required = false) InterviewType type,
             @RequestParam(required = false) String keyword
     ) {
         Pageable pageRequest = PageRequest.of(page, size);

--- a/src/main/java/com/aibe/team2/domain/mypage/service/MypageInterviewService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/MypageInterviewService.java
@@ -1,5 +1,7 @@
 package com.aibe.team2.domain.mypage.service;
 
+import com.aibe.team2.domain.interview.enums.InterviewMode;
+import com.aibe.team2.domain.interview.enums.InterviewType;
 import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
 import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +17,8 @@ public class MypageInterviewService {
 
     private final InterviewSessionRepository interviewSessionRepository;
 
-    public Page<InterviewSessionListResponse> getInterviewSessionList(Long memberId, Pageable pageable) {
+    public Page<InterviewSessionListResponse> getInterviewSessionList(Long memberId, InterviewType type, String keyword, Pageable pageable) {
 
-        return interviewSessionRepository.findInterviewSessionList(memberId, pageable);
+        return interviewSessionRepository.findInterviewSessionList(memberId, type, keyword, pageable);
     }
 }

--- a/src/main/java/com/aibe/team2/global/redis/RedisConfig.java
+++ b/src/main/java/com/aibe/team2/global/redis/RedisConfig.java
@@ -49,6 +49,7 @@ public class RedisConfig {
                 .allowIfBaseType("java.util")             // List, Map 등 자바 기본 컬렉션 허용
                 .allowIfBaseType("java.time")             // LocalDateTime 등 시간 객체 허용
                 .allowIfBaseType("java.lang")             // String, Long, Integer 등 기본 래퍼 타입 허용
+                .allowIfBaseType("java.math")             // [추가] BigDecimal 등 수학 관련 객체 허용!
                 .build();
 
         ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
## 작업 내용
- 마이 페이지 면접 세션 목록 조회 API에 면접 모드 필터링 및 키워드 검색 기능 추가
- QueryDSL을 활용해 검색 조건에 따른 동적 쿼리 구현
- Redis에 통계 등 수치 데이터 저장 시 BigDecimal 타입이 정상적으로 처리되도록 JSON 직렬화 설정 추가

<br/>

## 변경 사항 및 주의 사항
- 면접 목록 조회 API에 @RequestParam으로 mode와 keyword 파라미터 추가
- Controller로부터 전달받은 type과 keyword를 Repository로 전달하도록 메서드 시그니처 수정
- 인터페이스에 type과 keyword 매개변수 추가
- eqType(), containsKeyword() 메서드를 통한 QueryDSL 동적 쿼리 조건 추가
- 검색어 필터링이 올바르게 동작하도록 전체 개수 조회에도 resume, jobPosting 테이블 LEFT JOIN 추가
- PolymorphicTypeValidator 설정에 .allowIfBaseType("java.math")를 추가하여 수학 관련 객체 직렬화 허용

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
