### PR TITLE
[FEAT] 비정상 종료(ABORTED) 세션 마이페이지 및 통계 제외 처리 (FR-INT-09)

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
@@ -2,11 +2,15 @@ package com.aibe.team2.domain.interview.repository;
 
 import com.aibe.team2.domain.interview.entity.InterviewSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 
 public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long>, InterviewSessionRepositoryCustom {
 
     // 오늘 하루(Start~End)동안 생성된 면접 세션 개수 조회
-    long countByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+    // 🚀 [FR-INT-09] ABORTED 상태인 세션은 통계에서 제외 (Service 계층 코드 수정 방지)
+    @Query("SELECT count(i) FROM InterviewSession i WHERE i.memberId = :memberId AND i.status != 'ABORTED' AND i.createdAt BETWEEN :start AND :end")
+    long countByMemberIdAndCreatedAtBetween(@Param("memberId") Long memberId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
@@ -11,6 +11,6 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
 
     // 오늘 하루(Start~End)동안 생성된 면접 세션 개수 조회
     // [FR-INT-09] ABORTED 상태인 세션은 통계에서 제외 (Service 계층 코드 수정 방지)
-    @Query("SELECT count(i) FROM InterviewSession i WHERE i.memberId = :memberId AND i.status != 'ABORTED' AND i.createdAt BETWEEN :start AND :end")
+    @Query("SELECT count(i) FROM InterviewSession i WHERE i.memberId = :memberId AND i.status <> com.aibe.team2.domain.interview.enums.InterviewSessionStatus.ABORTED AND i.createdAt BETWEEN :start AND :end")
     long countByMemberIdAndCreatedAtBetween(@Param("memberId") Long memberId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long>, InterviewSessionRepositoryCustom {
 
     // 오늘 하루(Start~End)동안 생성된 면접 세션 개수 조회
-    // 🚀 [FR-INT-09] ABORTED 상태인 세션은 통계에서 제외 (Service 계층 코드 수정 방지)
+    // [FR-INT-09] ABORTED 상태인 세션은 통계에서 제외 (Service 계층 코드 수정 방지)
     @Query("SELECT count(i) FROM InterviewSession i WHERE i.memberId = :memberId AND i.status != 'ABORTED' AND i.createdAt BETWEEN :start AND :end")
     long countByMemberIdAndCreatedAtBetween(@Param("memberId") Long memberId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.aibe.team2.domain.interview.repository;
 
+import com.aibe.team2.domain.interview.enums.InterviewSessionStatus; // [FR-INT-09] 상태 Enum 임포트
 import com.aibe.team2.domain.interview.enums.InterviewType;
 import com.aibe.team2.domain.mypage.dto.response.InterviewSessionListResponse;
 import com.querydsl.core.types.Projections;
@@ -20,7 +21,7 @@ import static com.aibe.team2.domain.resume.entity.QResume.resume;
 @RequiredArgsConstructor
 public class InterviewSessionRepositoryImpl implements InterviewSessionRepositoryCustom {
 
-    private final JPAQueryFactory  queryFactory;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public List<InterviewSessionListResponse> findInterviewSessionList(
@@ -36,6 +37,7 @@ public class InterviewSessionRepositoryImpl implements InterviewSessionRepositor
                 .leftJoin(jobPosting).on(interviewSession.jobPostingId.eq(jobPosting.id))
                 .where(
                         interviewSession.memberId.eq(memberId),
+                        interviewSession.status.ne(InterviewSessionStatus.ABORTED), // [FR-INT-09] 비정상 종료 세션 제외 조건 추가
                         eqType(type),
                         containsKeyword(keyword)
                 );


### PR DESCRIPTION
## 관련 이슈
- closed: #139

## 작업 내용
네트워크 오류나 브라우저 강제 이탈로 발생한 ABORTED (비정상 종료) 상태의 면접 세션이 마이페이지 '면접 기록 목록'과 '대시보드 통계'에 노출되는 데이터 정합성 문제를 해결

- 마이페이지 목록 필터링 (InterviewSessionRepositoryImpl.java):
  - QueryDSL baseQuery의 .where() 절에 status.ne(ABORTED) 조건을 추가하여 DB 조회 단계에서 더미 데이터를 차단
- 기존 동적 검색 로직(keyword, type)과 반환 타입을 보존하여 프론트엔드 연동에 영향을 주지 않도록 구현
- 대시보드 통계 필터링 (InterviewSessionRepository.java):
  - countByMemberIdAndCreatedAtBetween 메서드에 @Query를 명시적으로 선언하고 상태 필터링 조건을 추가
 
<br/>

## 변경 사항 및 주의 사항
- 통계 및 목록 조회 쿼리의 WHERE 절에 status 조건이 추가되어 추후 데이터가 방대해질 경우 해당 컬럼에 대한 복합 인덱스 추가 및 실행 계획 점검이 필요할 수 있음

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #
