### PR TITLE
[FEAT] 관리자 검색 조건 및 사용량 통계 기능 개선

### DIFF
--- a/src/main/java/com/aibe/team2/domain/admin/controller/AdminMemberController.java
+++ b/src/main/java/com/aibe/team2/domain/admin/controller/AdminMemberController.java
@@ -11,6 +11,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -27,6 +29,7 @@ public class AdminMemberController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<AdminMemberRow>>> searchMembers(
             @ModelAttribute AdminMemberSearchCond cond,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
         Page<AdminMemberRow> result = adminMemberService.searchMembers(cond, pageable);

--- a/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
@@ -1,11 +1,13 @@
 package com.aibe.team2.domain.mypage.entity;
 
-import com.aibe.team2.domain.mypage.entity.enums.Role;
-import com.aibe.team2.domain.mypage.entity.enums.Provider;
-import com.aibe.team2.domain.mypage.entity.enums.SubscriptionPlan;
 import com.aibe.team2.domain.mypage.entity.enums.MemberStatus;
+import com.aibe.team2.domain.mypage.entity.enums.Provider;
+import com.aibe.team2.domain.mypage.entity.enums.Role;
+import com.aibe.team2.domain.mypage.entity.enums.SubscriptionPlan;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -57,10 +59,12 @@ public class Member {
     @Column(name = "credit_balance")
     private Integer creditBalance;
 
-    @Column(name = "created_at", updatable = false)
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at")
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")

--- a/src/main/java/com/aibe/team2/domain/mypage/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/repository/member/MemberRepositoryImpl.java
@@ -66,7 +66,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 ))
                 .from(member)
                 .where(where)
-                .orderBy(member.createdAt.desc())
+                .orderBy(member.createdAt.desc().nullsLast())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/admin/AdminMemberUsageSummaryResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/admin/AdminMemberUsageSummaryResponse.java
@@ -12,8 +12,10 @@ public class AdminMemberUsageSummaryResponse {
     private Integer creditBalance;
 
     private Long totalLogCount;
-    private Long totalTokenUsage;
 
     private Long resumeUsageCount;
     private Long interviewUsageCount;
+
+    private Long serviceTokenUsage;   // 실제 서비스 사용 토큰
+    private Long adminCreditDelta;    // 관리자 크레딧 변동량
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/admin/AdminServiceUsageSummaryResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/admin/AdminServiceUsageSummaryResponse.java
@@ -6,8 +6,17 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class AdminServiceUsageSummaryResponse {
-    private Long resumeUsage;
-    private Long interviewUsage;
-    private Long adminOperations;
-    private Long totalUsage;
+
+    // 사용 건수
+    private Long resumeUsageCount;
+    private Long interviewUsageCount;
+    private Long adminOperationCount;
+
+    // 합계
+    private Long totalServiceUsageCount;   // RESUME + INTERVIEW
+    private Long totalOverallLogCount;     // RESUME + INTERVIEW + ADMIN
+
+    // 양 분리
+    private Long serviceTokenUsage;        // 실제 서비스(RESUME, INTERVIEW) tokenUsage 합
+    private Long adminCreditDelta;         // 관리자 지급/차감 합계
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/admin/UsageLogAdminSearchCond.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/admin/UsageLogAdminSearchCond.java
@@ -12,6 +12,8 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class UsageLogAdminSearchCond {
     private Long memberId;
+    private String nickname;
+    private String email;
     private ServiceType serviceType;
     private LocalDate from;
     private LocalDate to;

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/usage/UsageLogRepository.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/usage/UsageLogRepository.java
@@ -80,9 +80,45 @@ where u.member.memberId = :memberId
     );
 
     @Query("""
-    select coalesce(sum(u.tokenUsage), 0)
-    from UsageLog u
-    where u.createdAt >= :start and u.createdAt < :end
+select coalesce(sum(u.tokenUsage), 0)
+from UsageLog u
+where u.serviceType = :serviceType
+""")
+    Long sumTokenUsageByServiceType(@Param("serviceType") ServiceType serviceType);
+
+    @Query("""
+select coalesce(sum(u.tokenUsage), 0)
+from UsageLog u
+where u.serviceType in :serviceTypes
+""")
+    Long sumTokenUsageByServiceTypes(@Param("serviceTypes") List<ServiceType> serviceTypes);
+
+    @Query("""
+select coalesce(sum(u.tokenUsage), 0)
+from UsageLog u
+where u.member.memberId = :memberId
+  and u.serviceType = :serviceType
+""")
+    Long sumTokenUsageByMemberIdAndServiceType(
+            @Param("memberId") Long memberId,
+            @Param("serviceType") ServiceType serviceType
+    );
+
+    @Query("""
+select coalesce(sum(u.tokenUsage), 0)
+from UsageLog u
+where u.member.memberId = :memberId
+  and u.serviceType in :serviceTypes
+""")
+    Long sumTokenUsageByMemberIdAndServiceTypes(
+            @Param("memberId") Long memberId,
+            @Param("serviceTypes") List<ServiceType> serviceTypes
+    );
+
+    @Query("""
+select coalesce(sum(u.tokenUsage), 0)
+from UsageLog u
+where u.createdAt >= :start and u.createdAt < :end
 """)
     Long sumTokenUsageByCreatedAtRange(
             @Param("start") LocalDateTime start,

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/usage/UsageLogRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/usage/UsageLogRepositoryImpl.java
@@ -59,13 +59,18 @@ public class UsageLogRepositoryImpl implements UsageLogRepositoryCustom {
             if (cond.getMemberId() != null) {
                 where.and(usageLog.member.memberId.eq(cond.getMemberId()));
             }
+            if (cond.getNickname() != null && !cond.getNickname().isBlank()) {
+                where.and(usageLog.member.nickname.containsIgnoreCase(cond.getNickname()));
+            }
+            if (cond.getEmail() != null && !cond.getEmail().isBlank()) {
+                where.and(usageLog.member.email.containsIgnoreCase(cond.getEmail()));
+            }
             if (cond.getServiceType() != null) {
                 where.and(usageLog.serviceType.eq(cond.getServiceType()));
             }
             if (cond.getTargetType() != null && !cond.getTargetType().isBlank()) {
                 where.and(usageLog.targetType.eq(cond.getTargetType()));
             }
-
             if (cond.getFrom() != null) {
                 LocalDateTime from = cond.getFrom().atStartOfDay();
                 where.and(usageLog.createdAt.goe(from));

--- a/src/main/java/com/aibe/team2/domain/statistics/service/AdminUsageService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/AdminUsageService.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 public class AdminUsageService {
 
     private final UsageLogRepository usageLogRepository;
+    private final MemberRepository memberRepository;
 
     public List<DailyUsageAdminRow> getDailyUsage(LocalDate date) {
         LocalDateTime start = date.atStartOfDay();
@@ -50,49 +51,75 @@ public class AdminUsageService {
         return usageLogRepository.searchAdminUsageLogs(cond, pageable);
     }
 
-    private final MemberRepository memberRepository;
-
     public AdminMemberUsageSummaryResponse getMemberUsageSummary(Long memberId) {
         Member member = memberRepository.getByIdThrow(memberId);
 
         Long totalLogCount = usageLogRepository.countByMember_MemberId(memberId);
-        Long totalTokenUsage = usageLogRepository.sumTokenUsageByMemberId(memberId);
-        Long resumeUsageCount = usageLogRepository.countByMember_MemberIdAndServiceType(memberId, ServiceType.RESUME);
-        Long interviewUsageCount = usageLogRepository.countByMember_MemberIdAndServiceType(memberId, ServiceType.INTERVIEW);
 
-        if (totalTokenUsage == null) {
-            totalTokenUsage = 0L;
-        }
+        Long resumeUsageCount =
+                usageLogRepository.countByMember_MemberIdAndServiceType(memberId, ServiceType.RESUME);
+
+        Long interviewUsageCount =
+                usageLogRepository.countByMember_MemberIdAndServiceType(memberId, ServiceType.INTERVIEW);
+
+        Long serviceTokenUsage =
+                usageLogRepository.sumTokenUsageByMemberIdAndServiceTypes(
+                        memberId,
+                        List.of(ServiceType.RESUME, ServiceType.INTERVIEW)
+                );
+
+        Long adminCreditDelta =
+                usageLogRepository.sumTokenUsageByMemberIdAndServiceType(
+                        memberId,
+                        ServiceType.ADMIN
+                );
 
         return new AdminMemberUsageSummaryResponse(
                 member.getMemberId(),
                 member.getEmail(),
                 member.getCreditBalance(),
                 totalLogCount,
-                totalTokenUsage,
                 resumeUsageCount,
-                interviewUsageCount
+                interviewUsageCount,
+                nullToZero(serviceTokenUsage),
+                nullToZero(adminCreditDelta)
         );
     }
 
     public AdminServiceUsageSummaryResponse getServiceUsageSummary() {
 
-        long resumeUsage =
+        long resumeUsageCount =
                 usageLogRepository.countByServiceType(ServiceType.RESUME);
 
-        long interviewUsage =
+        long interviewUsageCount =
                 usageLogRepository.countByServiceType(ServiceType.INTERVIEW);
 
-        long adminOperations =
+        long adminOperationCount =
                 usageLogRepository.countByServiceType(ServiceType.ADMIN);
 
-        long totalUsage = resumeUsage + interviewUsage + adminOperations;
+        long totalServiceUsageCount = resumeUsageCount + interviewUsageCount;
+        long totalOverallLogCount = totalServiceUsageCount + adminOperationCount;
+
+        Long serviceTokenUsage =
+                usageLogRepository.sumTokenUsageByServiceTypes(
+                        List.of(ServiceType.RESUME, ServiceType.INTERVIEW)
+                );
+
+        Long adminCreditDelta =
+                usageLogRepository.sumTokenUsageByServiceType(ServiceType.ADMIN);
 
         return new AdminServiceUsageSummaryResponse(
-                resumeUsage,
-                interviewUsage,
-                adminOperations,
-                totalUsage
+                resumeUsageCount,
+                interviewUsageCount,
+                adminOperationCount,
+                totalServiceUsageCount,
+                totalOverallLogCount,
+                nullToZero(serviceTokenUsage),
+                nullToZero(adminCreditDelta)
         );
+    }
+
+    private Long nullToZero(Long value) {
+        return value == null ? 0L : value;
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #163

## 작업 내용

- 관리자 회원 검색 조건 보완
- 사용량 로그 검색 조건 확장
- 사용량 통계 DTO 및 집계 로직 개선
- 회원 엔티티 createdAt / updatedAt 반영

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다