### PR TITLE
[FEAT] 마이페이지 신규 API 엔드포인트 추가 및 면접 통계 DTO 세분화

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/com/aibe/team2/domain/interview/repository/InterviewSessionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface InterviewSessionRepository extends JpaRepository<InterviewSession, Long>, InterviewSessionRepositoryCustom {
 
@@ -13,4 +14,6 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
     // [FR-INT-09] ABORTED 상태인 세션은 통계에서 제외 (Service 계층 코드 수정 방지)
     @Query("SELECT count(i) FROM InterviewSession i WHERE i.memberId = :memberId AND i.status <> com.aibe.team2.domain.interview.enums.InterviewSessionStatus.ABORTED AND i.createdAt BETWEEN :start AND :end")
     long countByMemberIdAndCreatedAtBetween(@Param("memberId") Long memberId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    List<InterviewSession> findTop5ByMemberIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MemberController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.aibe.team2.domain.mypage.controller;
 
-import com.aibe.team2.domain.auth.dto.CustomUserDetails;
 import com.aibe.team2.domain.mypage.dto.response.MemberResponse;
 import com.aibe.team2.domain.mypage.dto.response.MemberUpdateResponse;
 import com.aibe.team2.domain.mypage.dto.request.PasswordChangeRequest;
@@ -13,7 +12,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -65,6 +63,23 @@ public class MemberController {
                 .code("OK")
                 .message("프로필 이미지 수정이 완료되었습니다.")
                 .data(uploadedUrl)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    // 프로필 이미지 삭제
+    @DeleteMapping("/profile/image")
+    public ResponseEntity<ApiResponse<Void>> deleteProfileImage(
+            @LoginMemberId Long memberId
+    ) {
+        // MemberService에 이미지 삭제 로직을 위임합니다.
+        memberService.deleteProfileImage(memberId);
+
+        ApiResponse<Void> apiResponse = ApiResponse.<Void> builder()
+                .success(true)
+                .code("OK")
+                .message("프로필 이미지가 기본 이미지로 변경되었습니다.")
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MyPageRecentActivityController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MyPageRecentActivityController.java
@@ -1,0 +1,29 @@
+package com.aibe.team2.domain.mypage.controller;
+
+import com.aibe.team2.domain.mypage.service.RecentActivityService;
+import com.aibe.team2.domain.mypage.dto.response.RecentActivityResponse;
+import com.aibe.team2.global.common.annotation.LoginMemberId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/mypage") // /statistics가 빠진 깔끔한 경로
+@RequiredArgsConstructor
+public class MyPageRecentActivityController {
+
+    private final RecentActivityService recentActivityService;
+
+    // GET /api/v1/mypage/recent-activities
+    @GetMapping("/recent-activities")
+    public ResponseEntity<List<RecentActivityResponse>> getRecentActivities(
+            @LoginMemberId Long memberId
+    ) {
+        List<RecentActivityResponse> response = recentActivityService.getRecentActivities(memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/MypageInterviewController.java
@@ -6,7 +6,6 @@ import com.aibe.team2.domain.mypage.service.MypageInterviewService;
 import com.aibe.team2.global.common.annotation.LoginMemberId;
 import com.aibe.team2.global.redis.ratelimit.RateLimit;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/aibe/team2/domain/mypage/controller/QuestionScrapController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/QuestionScrapController.java
@@ -2,6 +2,7 @@ package com.aibe.team2.domain.mypage.controller;
 
 import com.aibe.team2.domain.auth.dto.CustomUserDetails;
 import com.aibe.team2.domain.mypage.dto.response.BookmarkResponse;
+import com.aibe.team2.domain.mypage.dto.response.BookmarkStatsResponse;
 import com.aibe.team2.domain.mypage.service.QuestionScrapService;
 import com.aibe.team2.global.common.annotation.LoginMemberId;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,6 +56,19 @@ public class QuestionScrapController {
         log.info("[북마크 목록 조회] MemberId: {}",  memberId);
 
         Page<BookmarkResponse> response = questionScrapService.getMyBookmarks(memberId, pageable);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // [대시보드/북마크] 내 북마크(스크랩) 요약 통계 조회
+    @GetMapping("/bookmarks/stats")
+    public ResponseEntity<BookmarkStatsResponse> getBookmarkStats(
+            @LoginMemberId Long memberId
+    ) {
+        log.info("Bookmark stats requested. memberId: {}", memberId);
+
+        // 서비스 호출 (아래 3번 참조)
+        BookmarkStatsResponse response = questionScrapService.getBookmarkStats(memberId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/response/BookmarkStatsResponse.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/response/BookmarkStatsResponse.java
@@ -1,0 +1,6 @@
+package com.aibe.team2.domain.mypage.dto.response;
+
+public record BookmarkStatsResponse(
+        long totalBookmarkCount
+) {
+}

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/response/RecentActivityResponse.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/response/RecentActivityResponse.java
@@ -1,0 +1,11 @@
+package com.aibe.team2.domain.mypage.dto.response;
+
+import java.time.LocalDateTime;
+
+public record RecentActivityResponse(
+        Long id,
+        String type,        // "RESUME" 또는 "INTERVIEW"
+        String title,       // 자소서 제목 또는 면접 직무명
+        LocalDateTime createdAt,
+        Integer score       // 자소서는 null 허용, 면접은 최종 점수
+) {}

--- a/src/main/java/com/aibe/team2/domain/mypage/repository/bookmark/QuestionScrapRepository.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/repository/bookmark/QuestionScrapRepository.java
@@ -14,4 +14,7 @@ public interface QuestionScrapRepository extends JpaRepository<QuestionScrap, Lo
     Optional<QuestionScrap> findByMemberAndInterviewRecord(Member member, InterviewRecord interviewRecord);
 
     long countByInterviewRecordId(long interviewRecordId);
+
+    // QuestionScrapRepository 내부에 추가 (없다면)
+    long countByMember_MemberId(Long memberId);
 }

--- a/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/MemberService.java
@@ -140,6 +140,21 @@ public class MemberService {
         return newImageUrl;
     }
 
+    // 프로필 이미지 삭제
+    @Transactional
+    public void deleteProfileImage(Long memberId) {
+        // 1. DB에서 멤버 조회 (기존에 정의된 메서드 활용)
+        Member member = memberRepository.getByIdThrow(memberId);
+
+        // 2. 기존 이미지가 S3 같은 클라우드에 있다면 실제 파일 삭제 처리
+        if (member.getProfileImageUrl() != null) {
+            s3ImageService.deleteImage(member.getProfileImageUrl());
+        }
+
+        // 3. DB의 프로필 이미지 URL을 null로 업데이트
+        member.updateProfileImage(null);
+    }
+
     public void validateSignup(MemberDTO request) {
         // 1. 닉네임 중복 검사
         if (memberRepository.existsByNickname(request.getNickname())) {

--- a/src/main/java/com/aibe/team2/domain/mypage/service/QuestionScrapService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/QuestionScrapService.java
@@ -3,6 +3,7 @@ package com.aibe.team2.domain.mypage.service;
 import com.aibe.team2.domain.jobposting.entity.JobPosting;
 import com.aibe.team2.domain.jobposting.repository.JobPostingRepository;
 import com.aibe.team2.domain.mypage.dto.response.BookmarkResponse;
+import com.aibe.team2.domain.mypage.dto.response.BookmarkStatsResponse;
 import com.aibe.team2.domain.mypage.entity.Member;
 import com.aibe.team2.domain.mypage.entity.QuestionScrap;
 import com.aibe.team2.domain.mypage.repository.bookmark.QuestionScrapRepository;
@@ -148,5 +149,13 @@ public class QuestionScrapService {
 
             return BookmarkResponse.from(scrap, jobPosting);
         });
+    }
+
+    @Transactional(readOnly = true)
+    public BookmarkStatsResponse getBookmarkStats(Long memberId) {
+        // Repository에서 멤버의 북마크 총 갯수를 가져옴
+        long totalBookmarks = questionScrapRepository.countByMember_MemberId(memberId);
+
+        return new BookmarkStatsResponse(totalBookmarks);
     }
 }

--- a/src/main/java/com/aibe/team2/domain/mypage/service/RecentActivityService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/RecentActivityService.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -24,27 +25,29 @@ public class RecentActivityService {
         List<RecentActivityResponse> combinedActivities = new ArrayList<>();
 
         // 1. 최신 자소서 5개 가져와서 DTO로 변환
-        resumeAnalysisRepository.findTop5ByResume_MemberIdOrderByCreatedAtDesc(memberId)
-                .forEach(report -> combinedActivities.add(new RecentActivityResponse(
+        var resumeActivities = resumeAnalysisRepository.findTop5ByResume_MemberIdOrderByCreatedAtDesc(memberId)
+                .stream()
+                .map(report -> new RecentActivityResponse(
                         report.getId(),
                         "RESUME",
                         report.getResume().getTitle(), // 자소서 제목
                         report.getCreatedAt(),
                         null // 자소서는 점수가 없으므로 null
-                )));
+                ));
 
         // 2. 최신 모의 면접 5개 가져와서 DTO로 변환
-        interviewSessionRepository.findTop5ByMemberIdOrderByCreatedAtDesc(memberId)
-                .forEach(session -> combinedActivities.add(new RecentActivityResponse(
+        var interviewActivities = interviewSessionRepository.findTop5ByMemberIdOrderByCreatedAtDesc(memberId)
+                .stream()
+                .map(session -> new RecentActivityResponse(
                         session.getId(),
                         "INTERVIEW",
                         session.getInterviewType(), // 예: "심층 면접"
                         session.getCreatedAt(),
                         session.getFinalScore() // 최종 점수
-                )));
+                ));
 
         // 3. 두 리스트를 합친 후(최대 10개), 시간을 기준으로 최신순 정렬하고 최종 상위 5개만 잘라서 반환
-        return combinedActivities.stream()
+        return Stream.concat(resumeActivities, interviewActivities)
                 .sorted(Comparator.comparing(RecentActivityResponse::createdAt).reversed())
                 .limit(5)
                 .collect(Collectors.toList());

--- a/src/main/java/com/aibe/team2/domain/mypage/service/RecentActivityService.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/service/RecentActivityService.java
@@ -1,0 +1,52 @@
+package com.aibe.team2.domain.mypage.service;
+
+import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
+import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
+import com.aibe.team2.domain.mypage.dto.response.RecentActivityResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 단순 조회이므로 readOnly = true로 성능 최적화
+public class RecentActivityService {
+
+    private final ResumeAnalysisRepository resumeAnalysisRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+
+    public List<RecentActivityResponse> getRecentActivities(Long memberId) {
+        List<RecentActivityResponse> combinedActivities = new ArrayList<>();
+
+        // 1. 최신 자소서 5개 가져와서 DTO로 변환
+        resumeAnalysisRepository.findTop5ByResume_MemberIdOrderByCreatedAtDesc(memberId)
+                .forEach(report -> combinedActivities.add(new RecentActivityResponse(
+                        report.getId(),
+                        "RESUME",
+                        report.getResume().getTitle(), // 자소서 제목
+                        report.getCreatedAt(),
+                        null // 자소서는 점수가 없으므로 null
+                )));
+
+        // 2. 최신 모의 면접 5개 가져와서 DTO로 변환
+        interviewSessionRepository.findTop5ByMemberIdOrderByCreatedAtDesc(memberId)
+                .forEach(session -> combinedActivities.add(new RecentActivityResponse(
+                        session.getId(),
+                        "INTERVIEW",
+                        session.getInterviewType(), // 예: "심층 면접"
+                        session.getCreatedAt(),
+                        session.getFinalScore() // 최종 점수
+                )));
+
+        // 3. 두 리스트를 합친 후(최대 10개), 시간을 기준으로 최신순 정렬하고 최종 상위 5개만 잘라서 반환
+        return combinedActivities.stream()
+                .sorted(Comparator.comparing(RecentActivityResponse::createdAt).reversed())
+                .limit(5)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/resume/dto/ResumeStatsResponse.java
+++ b/src/main/java/com/aibe/team2/domain/resume/dto/ResumeStatsResponse.java
@@ -1,0 +1,8 @@
+package com.aibe.team2.domain.resume.dto;
+
+public record ResumeStatsResponse(
+        long aiResumeCount,
+        long savedResumeCount,
+        long completedCount
+) {
+}

--- a/src/main/java/com/aibe/team2/domain/resume/repository/ResumeAnalysisRepository.java
+++ b/src/main/java/com/aibe/team2/domain/resume/repository/ResumeAnalysisRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -31,4 +32,6 @@ public interface ResumeAnalysisRepository extends JpaRepository<AnalyzedReport, 
             "WHERE res.memberId = :memberId",
             countQuery = "SELECT count(r) FROM AnalyzedReport r WHERE r.resume.memberId = :memberId")
     Page<AnalyzedReport> findByMemberIdWithDetails(@Param("memberId") Long memberId, Pageable pageable);
+
+    List<AnalyzedReport> findTop5ByResume_MemberIdOrderByCreatedAtDesc(Long memberId);
 }

--- a/src/main/java/com/aibe/team2/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/aibe/team2/domain/resume/repository/ResumeRepository.java
@@ -22,4 +22,13 @@ public interface ResumeRepository extends JpaRepository<Resume, Long> {
     // 채용공고의 벡터를 받아, 해당 직무에 가장 적합한 이력서 Top 5를 검색
     @Query(value = "SELECT * FROM resume ORDER BY embedding <=> cast(:jdVector as vector) LIMIT 5", nativeQuery = true)
     List<Resume> findTop5SimilarResumes(@Param("jdVector") String jdVectorString);
+
+    // =========================================================
+    // 대시보드 통계용
+    // =========================================================
+    // 1. 내 저장된 이력서 총 개수
+    long countByMemberId(Long memberId);
+
+    // 2. AI 분석 완료된 자소서 개수 (isAnalyzed 가 true인 것)
+    long countByMemberIdAndIsAnalyzedTrue(Long memberId);
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/GrowthStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/GrowthStatisticsController.java
@@ -1,13 +1,11 @@
 package com.aibe.team2.domain.statistics.controller;
 
-import com.aibe.team2.domain.auth.dto.CustomUserDetails;
 import com.aibe.team2.domain.statistics.dto.GrowthResultResponse;
 import com.aibe.team2.domain.statistics.service.GrowthStatisticsService;
 import com.aibe.team2.global.common.annotation.LoginMemberId;
 import com.aibe.team2.global.redis.ratelimit.RateLimit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/InterviewStatisticsController.java
@@ -1,6 +1,5 @@
 package com.aibe.team2.domain.statistics.controller;
 
-import com.aibe.team2.domain.auth.dto.CustomUserDetails;
 import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse;
 import com.aibe.team2.domain.statistics.service.InterviewStatisticsService;
 import com.aibe.team2.global.common.annotation.LoginMemberId;
@@ -9,7 +8,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/MemberStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/MemberStatisticsController.java
@@ -1,13 +1,11 @@
 package com.aibe.team2.domain.statistics.controller;
 
-import com.aibe.team2.domain.auth.dto.CustomUserDetails;
 import com.aibe.team2.domain.statistics.dto.usage.MonthlyUsageResponse;
 import com.aibe.team2.domain.statistics.service.MemberStatisticsService;
 import com.aibe.team2.global.common.annotation.LoginMemberId;
 import com.aibe.team2.global.redis.ratelimit.RateLimit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/aibe/team2/domain/statistics/controller/ResumeStatisticsController.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/controller/ResumeStatisticsController.java
@@ -1,5 +1,6 @@
 package com.aibe.team2.domain.statistics.controller;
 
+import com.aibe.team2.domain.resume.dto.ResumeStatsResponse;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisListResponse;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse;
 import com.aibe.team2.domain.statistics.service.ResumeStatisticsService;
@@ -43,6 +44,19 @@ public class ResumeStatisticsController {
             @PathVariable("analysisId") Long analysisId
     ){
         ResumeAnalysisResultResponse response = resumeStatisticsService.getResumeAnalysisReport(analysisId, memberId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    // 내 자기소개서 요약 통계 조회
+    @GetMapping("/stats")
+    public ResponseEntity<ResumeStatsResponse> getResumeStats(
+            @LoginMemberId Long memberId
+    ){
+        log.info("Dashboard resume stats requested. memberId: {}", memberId);
+
+        // 서비스 계층에 통계 데이터 요청
+        ResumeStatsResponse response = resumeStatisticsService.getResumeStats(memberId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewResultDetailResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewResultDetailResponse.java
@@ -1,10 +1,14 @@
 package com.aibe.team2.domain.statistics.dto.interview;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
 public record InterviewResultDetailResponse(
         Long sessionId,
+        String InterviewType,
+        String interviewMode,
+        LocalDateTime createdAt,
         Integer totalScore,
         String overallFeedback,
 
@@ -28,6 +32,7 @@ public record InterviewResultDetailResponse(
             Integer totalSilenceCount,
             Float avgSttAccuracy,
             Map<String, Object> emotionSummary,
+            List<String> frequentWords,
             List<String> habitDetails
     ) {}
 

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewResultDetailResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewResultDetailResponse.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 public record InterviewResultDetailResponse(
         Long sessionId,
-        String InterviewType,
+        String interviewType,
         String interviewMode,
         LocalDateTime createdAt,
         Integer totalScore,

--- a/src/main/java/com/aibe/team2/domain/statistics/repository/usage/UsageLogRepositoryImpl.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/repository/usage/UsageLogRepositoryImpl.java
@@ -26,15 +26,10 @@ public class UsageLogRepositoryImpl implements UsageLogRepositoryCustom {
     @Override
     public List<MonthlyUsageStatResponse> findMonthlyStats(Long memberId, int year) {
 
-        // [1] 날짜에서 '월' 추출
-        NumberTemplate<Integer> monthExpression = Expressions.numberTemplate(
-                Integer.class, "function('month', {0})", usageLog.createdAt
-        );
-
         return queryFactory
                 .select(Projections.constructor(
                         MonthlyUsageStatResponse.class,
-                        monthExpression,
+                        usageLog.createdAt.month(),
                         usageLog.serviceType.stringValue(),
                         usageLog.count(),
                         usageLog.amount.sum().longValue() // Integer sum을 Long으로 변환
@@ -45,8 +40,8 @@ public class UsageLogRepositoryImpl implements UsageLogRepositoryCustom {
                         usageLog.member.memberId.eq(memberId),
                         usageLog.createdAt.year().eq(year)
                 )
-                .groupBy(monthExpression, usageLog.serviceType)
-                .orderBy(monthExpression.asc())
+                .groupBy(usageLog.createdAt.month(), usageLog.serviceType)
+                .orderBy(usageLog.createdAt.month().asc())
                 .fetch();
     }
 

--- a/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
@@ -86,13 +86,13 @@ public class InterviewStatisticsService {
         String overallReview = (stats != null && stats.getOverallFeedback() != null)
                 ? stats.getOverallFeedback() : "";
 
-        String mappedInterviewType = convertInterviewModeToKorean(session.getInterviewMode());
-        String mappedInterviewMode = session.getInterviewType();
+        String interviewType = session.getInterviewType();
+        String interviewMode = convertInterviewModeToKorean(session.getInterviewMode());
 
         return new InterviewResultDetailResponse(
                 session.getId(),
-                mappedInterviewType,
-                mappedInterviewMode,
+                interviewType,
+                interviewMode,
                 session.getCreatedAt(),
                 session.getFinalScore(),
                 overallReview,

--- a/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
@@ -1,6 +1,7 @@
 package com.aibe.team2.domain.statistics.service;
 
 import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.enums.InterviewMode;
 import com.aibe.team2.domain.interview.repository.InterviewRepository;
 import com.aibe.team2.domain.statistics.dto.common.RadarChartStatResponse;
 import com.aibe.team2.domain.statistics.dto.interview.InterviewResultDetailResponse;
@@ -85,10 +86,16 @@ public class InterviewStatisticsService {
         String overallReview = (stats != null && stats.getOverallFeedback() != null)
                 ? stats.getOverallFeedback() : "";
 
+        String mappedInterviewType = convertInterviewModeToKorean(session.getInterviewMode());
+        String mappedInterviewMode = session.getInterviewType();
+
         return new InterviewResultDetailResponse(
                 session.getId(),
+                mappedInterviewType,
+                mappedInterviewMode,
+                session.getCreatedAt(),
                 session.getFinalScore(),
-                overallReview,// 임시 총평
+                overallReview,
                 logicAndStructure,
                 speechAnalysis,
                 turnScripts
@@ -116,7 +123,7 @@ public class InterviewStatisticsService {
     // --- 내부 통계 집계 로직 ---
     private SpeechAnalysis calculateSpeechAnalysis(List<InterviewRecord> records) {
         if (records == null || records.isEmpty()) {
-            return new SpeechAnalysis(0, 0, 0.0f, Collections.emptyMap(), Collections.emptyList());
+            return new SpeechAnalysis(0, 0, 0.0f, Collections.emptyMap(), Collections.emptyList(), Collections.emptyList());
         }
 
         int totalWpm = 0;
@@ -142,8 +149,20 @@ public class InterviewStatisticsService {
                 totalSilence,
                 avgStt,
                 formattedEmotionMap,
-                Collections.emptyList()
+                Collections.emptyList(), // [추가] frequentWords (많이 사용한 전문 용어 - 현재는 임시로 빈 리스트 반환)
+                Collections.emptyList()  // habitDetails (개선이 필요한 발화 습관 - 현재는 임시로 빈 리스트 반환)
         );
+    }
+
+    private String convertInterviewModeToKorean(InterviewMode mode) {
+        if (mode == null) {
+            return "일반"; // 기본값
+        }
+        return switch (mode) {
+            case NORMAL -> "일반";
+            case FOLLOW_UP -> "심층 꼬리질문";
+            case STRESS -> "압박";
+        };
     }
 
     // 소수점 첫째 자리 반올림 메서드

--- a/src/main/java/com/aibe/team2/domain/statistics/service/ResumeStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/ResumeStatisticsService.java
@@ -1,5 +1,6 @@
 package com.aibe.team2.domain.statistics.service;
 
+import com.aibe.team2.domain.resume.dto.ResumeStatsResponse;
 import com.aibe.team2.domain.resume.entity.AnalysisStatus;
 import com.aibe.team2.domain.resume.entity.AnalyzedReport;
 import com.aibe.team2.domain.resume.repository.ResumeAnalysisRepository;
@@ -8,6 +9,7 @@ import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse.CorrectionDetail;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse.EvaluationSummary;
 import com.aibe.team2.domain.statistics.dto.resume.ResumeAnalysisResultResponse.KeywordStats;
+import com.aibe.team2.domain.resume.repository.ResumeRepository;
 import com.aibe.team2.global.error.ErrorCode;
 import com.aibe.team2.global.exception.custom.ForbiddenException;
 import com.aibe.team2.global.exception.custom.NotFoundException;
@@ -31,6 +33,7 @@ import java.util.List;
 public class ResumeStatisticsService {
 
     private final ResumeAnalysisRepository resumeAnalysisRepository;
+    private final ResumeRepository resumeRepository;
     private final ObjectMapper objectMapper;
 
     // [FR-REP-04] 자기소개서 첨삭 이력 조회
@@ -112,5 +115,22 @@ public class ResumeStatisticsService {
                 isProcessing ? null : report.getRevisedFullContent(),
                 report.getCreatedAt()
         );
+    }
+
+    // [대시보드] 내 자기소개서 요약 통계 조회 로직
+    @Transactional(readOnly = true)
+    public ResumeStatsResponse getResumeStats(Long memberId) {
+
+        // 1. AI 자소서 (분석이 완료된 이력서)
+        long aiResumeCount = resumeRepository.countByMemberIdAndIsAnalyzedTrue(memberId);
+
+        // 2. 저장된 전체 이력서 개수
+        long savedResumeCount = resumeRepository.countByMemberId(memberId);
+
+        // 3. 작성 완료 개수 (임시 처리: 프론트엔드 에러를 막기 위해 일단 0으로 반환)
+        long completedCount = 0;
+
+        // 4. DTO에 담아서 반환
+        return new ResumeStatsResponse(aiResumeCount, savedResumeCount, completedCount);
     }
 }


### PR DESCRIPTION
## 작업 내용
1. **마이페이지 및 회원(MyPage & Member) API 추가**
   - `@DeleteMapping("/profile/image")`: 프로필 이미지 삭제 및 기본 이미지 복구 API 구현
   - `@GetMapping("/recent-activities")`: 최근 활동(이력서/면접 내역) 목록 조회 API 및 `RecentActivityResponse` DTO 구현
   - `@GetMapping("/bookmarks/stats")`: 내 북마크 스크랩 요약 통계 조회 API 연동

2. **면접 상세 데이터(Interview) DTO 세분화 및 로직 개선**
   - `InterviewResultDetailResponse` DTO에 프론트엔드 요구사항에 맞춘 필드 추가 (면접 타입, 면접 모드, 생성일시)
   - DB에 저장된 영문 면접 모드(NORMAL, FOLLOW_UP, STRESS)를 프론트엔드 표출용 한글(일반, 심층 꼬리질문, 압박)로 변환하는 로직(`convertInterviewModeToKorean`) 추가

3. **Repository 계층 쿼리 추가**
   - `InterviewSessionRepository`: 오늘 하루 동안 생성된 면접 세션 중 취소(ABORTED) 상태를 제외하고 카운트하는 커스텀 `@Query` 구현

<br/>

## 변경 사항 및 주의 사항
- **제약 조건:** `SpeechAnalysis`의 추가 필드(`frequentWords`, `habitDetails`)는 현재 빈 리스트(`Collections.emptyList()`)를 반환하도록 임시 처리되어 있습니다. 추후 AI 분석 데이터 연동 시 구현이 필요합니다.
- **충돌 가능성:** 데이터베이스 조회(Repository) 및 응답 구조(DTO)가 변경되었으므로, 해당 클래스를 의존하는 다른 브랜치 작업과 충돌이 발생할 수 있습니다.

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
