### PR TITLE
[Refactor] 백엔드-프론트엔드 데이터 규격 일치화 및 직렬화 오류 수

### DIFF
--- a/src/main/java/com/aibe/team2/domain/mypage/controller/QuestionScrapController.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/controller/QuestionScrapController.java
@@ -1,6 +1,5 @@
 package com.aibe.team2.domain.mypage.controller;
 
-import com.aibe.team2.domain.auth.dto.CustomUserDetails;
 import com.aibe.team2.domain.mypage.dto.response.BookmarkResponse;
 import com.aibe.team2.domain.mypage.dto.response.BookmarkStatsResponse;
 import com.aibe.team2.domain.mypage.service.QuestionScrapService;
@@ -14,7 +13,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "마이페이지 - 북마크", description = "질문 북마크 관리 API")

--- a/src/main/java/com/aibe/team2/domain/mypage/dto/response/BookmarkResponse.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/dto/response/BookmarkResponse.java
@@ -20,6 +20,9 @@ public class BookmarkResponse {
     private String jobTitle;        // 직무명
     private Long linkedInterviewId; // [핵심] 상세 페이지 이동용 "티켓" (세션 ID)
     private LocalDateTime createdAt;// 북마크한 날짜
+    private String answerText;
+    private String feedbackText;
+    private String category;
 
     public static BookmarkResponse from(QuestionScrap scrap, JobPosting jobPosting) {
         var record = scrap.getInterviewRecord();
@@ -36,6 +39,9 @@ public class BookmarkResponse {
                 .jobTitle(job)
                 .linkedInterviewId(session.getId())
                 .createdAt(scrap.getCreatedAt())
+                .answerText(record.getAnswerText())
+                .feedbackText(record.getFeedbackText())
+                .category(record.getQuestionIntent())
                 .build();
     }
 }

--- a/src/main/java/com/aibe/team2/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/aibe/team2/domain/notification/controller/NotificationController.java
@@ -1,13 +1,11 @@
 package com.aibe.team2.domain.notification.controller;
 
-import com.aibe.team2.domain.auth.dto.CustomUserDetails;
 import com.aibe.team2.domain.notification.service.NotificationService;
 import com.aibe.team2.global.common.annotation.LoginMemberId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 

--- a/src/main/java/com/aibe/team2/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/aibe/team2/domain/notification/dto/NotificationResponse.java
@@ -1,17 +1,20 @@
 package com.aibe.team2.domain.notification.dto;
 
 import com.aibe.team2.domain.notification.entity.Notification;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 public class NotificationResponse {
-    private Long id;
-    private String message;
-    private String notificationType;
-    private boolean isRead;
-    private LocalDateTime createdAt;
+    private final Long id;
+    private final String message;
+    private final String notificationType;
+
+    @JsonProperty("isRead")
+    private final boolean isRead;
+    private final LocalDateTime createdAt;
 
     // 엔티티를 DTO로 변환하는 생성자
     public NotificationResponse(Notification notification) {

--- a/src/main/java/com/aibe/team2/domain/notification/service/NotificationEventListener.java
+++ b/src/main/java/com/aibe/team2/domain/notification/service/NotificationEventListener.java
@@ -21,7 +21,7 @@ public class NotificationEventListener {
         log.info("[Notification] 이력서 분석 완료 이벤트를 수신했습니다. 알림을 발송합니다. memberId: {}", event.memberId());
 
         String type = "AI_ANALYSIS_COMPLETE";
-        String message = "이력서 AI 분석이 성공적으로 완료되었습니다! 결과를 확인해보세요!";
+        String message = "자기소개서 AI 분석이 성공적으로 완료되었습니다! 결과를 확인해보세요!";
 
         notificationService.send(event.memberId(), type, message);
     }

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewResultDetailResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/interview/InterviewResultDetailResponse.java
@@ -38,6 +38,7 @@ public record InterviewResultDetailResponse(
 
     // 3. 대화 복기 및 개별 비언어 지표 (파라미터 10개 완벽 매칭)
     public record TurnScript(
+            Long recordId,
             Integer turnSequence,
             String questionText,
             String answerText,

--- a/src/main/java/com/aibe/team2/domain/statistics/dto/resume/ResumeAnalysisListResponse.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/dto/resume/ResumeAnalysisListResponse.java
@@ -14,11 +14,15 @@ public record ResumeAnalysisListResponse(
         LocalDateTime createdAt // 분석 요청 일시
 ) {
     public static ResumeAnalysisListResponse from(AnalyzedReport report){
+        // 공고 정보가 있는지 확인
+        boolean hasJobPosting = report.getJobPosting() != null;
+
         return new ResumeAnalysisListResponse(
                 report.getId(),
-                report.getResume().getTitle(),               // 연관된 이력서에서 제목 추출
-                report.getJobPosting().getCompanyName(),     // 연관된 공고에서 회사명 추출
-                report.getJobPosting().getJobTitle(),        // 연관된 공고에서 직무 추출
+                report.getResume().getTitle(),
+                // 공고가 없으면 "자유 양식" 등의 기본 텍스트 반환
+                hasJobPosting ? report.getJobPosting().getCompanyName() : "일반 첨삭(자유 양식)",
+                hasJobPosting ? report.getJobPosting().getJobTitle() : "-",
                 report.getMatchScore(),
                 report.getStatus().name(),
                 report.getCreatedAt()

--- a/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/service/InterviewStatisticsService.java
@@ -68,12 +68,13 @@ public class InterviewStatisticsService {
         // 7. 턴별 스크립트 매핑 (파라미터 10개 매칭)
         List<TurnScript> turnScripts = records.stream()
                 .map(record -> new TurnScript(
+                        record.getId(),                  // 💡 [추가] 누락된 Long 타입 ID (메서드명은 엔티티에 맞게 확인 필요)
                         record.getTurnSequence(),
                         record.getQuestionText(),
                         record.getAnswerText(),
                         record.getFeedbackText(),
                         record.getEvaluationScore() != null ? record.getEvaluationScore().doubleValue() : 0.0,
-                        Collections.emptyList(),
+                        Collections.<String>emptyList(), // 💡 [수정] List<String>으로 명시적 타입 추론 지시
                         record.getWpm(),
                         record.getSilenceCount(),
                         record.getSttAccuracy(),


### PR DESCRIPTION
## 작업 내용
- ResumeAnalysisListResponse 수정 (Null 안전성 확보): 공고(JobPosting) 정보가 없는 '자유 양식' 이력서 조회 시 발생할 수 있는 NullPointerException을 방지하기 위해 예외 처리 로직 및 기본값("일반 첨삭(자유 양식)") 추가.
- NotificationResponse 수정 (직렬화 및 불변성 적용): - Jackson 라이브러리의 직렬화(Serialization) 과정에서 isRead 필드가 read로 변환되는 문제를 해결하기 위해 @JsonProperty("isRead") 어노테이션 명시.
- 데이터의 무결성을 위해 모든 필드에 final 키워드를 적용하여 불변성(Immutability) 보장.
- TurnScript 및 InterviewStatisticsService 데이터 규격 일치: 프론트엔드 요구사항에 맞춰 식별자인 Long recordId 필드를 추가하고, Collections.<String>emptyList()를 통해 명시적으로 타입 추론(Type Inference)을 지정하여 컴파일러 경고 해결.
- BookmarkResponse 응답 필드 추가: React 컴포넌트 화면 출력에 필요한 answerText, feedbackText, category 필드를 DTO에 추가하여 데이터 규격 일치화.

<br/>

## 변경 사항 및 주의 사항
- [프론트엔드 파트 주의 사항] 알림 내역 조회 API의 응답 데이터에서 읽음 여부를 나타내는 필드명이 기존에 변형되던 read가 아닌, 명세서와 동일한 isRead로 정상 반환됩니다. 연동 시 참고 부탁드립니다.
- 북마크 목록 및 인터뷰 결과 상세 조회 API의 응답(Response) 객체에 프론트엔드 요청에 따른 새로운 필드(recordId, answerText 등)가 다수 추가되었습니다.

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

