### PR TITLE
feat: SQS 컨슈머 비즈니스 로직 연동 및 면접 상세 기록 DB 저장 구현

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/controller/WebhookController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/WebhookController.java
@@ -4,6 +4,7 @@ import com.aibe.team2.domain.interview.dto.RetellWebhookRequest;
 import com.aibe.team2.domain.interview.service.WebhookService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,6 +22,10 @@ public class WebhookController {
 
     private final WebhookService webhookService;
     private final ObjectMapper objectMapper;
+    private final SqsTemplate sqsTemplate;
+
+    @Value("${cloud.aws.sqs.webhook-queue-name:retell-webhook-queue}")
+    private String webhookQueueName;
 
     @Value("${retell.webhook.secret}")
     private String webhookApiKey;
@@ -58,7 +63,9 @@ public class WebhookController {
     }
 
     private void processWebhookSynchronously(RetellWebhookRequest request) {
-        webhookService.processRetellWebhook(request);
+        // webhookService.processRetellWebhook(request);
+        log.info("📤 SQS Producer: 대화 분석 완료 데이터를 큐에 전송합니다. Queue: {}", webhookQueueName);
+        sqsTemplate.send(webhookQueueName, request);
     }
 
     private boolean isValidSignature(byte[] payloadBytes, String signature) {

--- a/src/main/java/com/aibe/team2/domain/interview/dto/RetellWebhookRequest.java
+++ b/src/main/java/com/aibe/team2/domain/interview/dto/RetellWebhookRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
 import java.util.Map;
 
 @Getter
@@ -27,5 +28,19 @@ public class RetellWebhookRequest {
 
         // 생성 시 넘겨주었던 metadata (여기에 session_id가 포함됨)
         private Map<String, Object> metadata;
+
+        @JsonProperty("transcript_object")
+        private List<TranscriptTurn> transcriptObject;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class TranscriptTurn {
+        // 발화자가 누구인지 ("agent" = AI 면접관, "user" = 사용자)
+        private String role;
+
+        // 실제 대화 내용
+        private String content;
     }
 }

--- a/src/main/java/com/aibe/team2/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/com/aibe/team2/domain/interview/entity/InterviewSession.java
@@ -69,4 +69,10 @@ public class InterviewSession {
     public void updateStatus(InterviewSessionStatus status) {
         this.status = status;
     }
+
+    // 최종 결과 업데이트 (SQS 분석 완료 시 사용)
+    public void updateResult(Integer finalScore) {
+        this.finalScore = finalScore;
+        this.status = InterviewSessionStatus.DONE;
+    }
 }

--- a/src/main/java/com/aibe/team2/domain/interview/service/InterviewRecordService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/InterviewRecordService.java
@@ -5,6 +5,8 @@ import com.aibe.team2.domain.interview.entity.InterviewSession;
 import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
 import com.aibe.team2.domain.statistics.entity.InterviewRecord;
 import com.aibe.team2.domain.statistics.repository.interview.InterviewRecordRepository;
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,33 +29,59 @@ public class InterviewRecordService {
         // 1. Session ID 추출
         Map<String, Object> metadata = request.getCall().getMetadata();
         if(metadata == null || !metadata.containsKey("session_id")) {
-            log.error("❌ 대화 기록 저장 실패: session_id가 존재하지 않습니다.");
-            return;
+            log.error("❌ 대화 기록 저장 실패: SQS 메시지에 session_id가 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.COMMON_407); // 필수 값 누락 예외 발생
         }
-        Long sessionId = Long.valueOf(metadata.get("session_id").toString());
+        Long sessionId;
 
-        // 2. 부모ㅓ 객체인 InterviewSession 조회
+        try {
+            sessionId = Long.valueOf(metadata.get("session_id").toString());
+        } catch (NumberFormatException e) {
+            log.error("❌ 대화 기록 저장 실패: 유효하지 않은 session_id 형식입니다. value: {}", metadata.get("session_id"));
+            throw new BusinessException(ErrorCode.COMMON_406); // 타입 불일치 예외 발생
+        }
+
+        // 2. 부모 객체인 InterviewSession 조회
         InterviewSession session = interviewSessionRepository.findById(sessionId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 세션을 찾을 수 없습니다. : " + sessionId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.INTERVIEW_SESSION_NOT_FOUND));
 
         // 3. 대화 내역 추출 및 엔티티 변환
         List<InterviewRecord> recordsToSave = new ArrayList<>();
-
+        List<RetellWebhookRequest.TranscriptTurn> turns = request.getCall().getTranscriptObject();
         int turnSequence = 1;
-        for (RetellWebhookRequest.TranscriptTurn turn : request.getCall().getTranscriptObject()) {
-            InterviewRecord record = InterviewRecord.builder()
+
+        for (int i = 0; i < turns.size(); i++) {
+            RetellWebhookRequest.TranscriptTurn currentTurn = turns.get(i);
+            String question = null;
+            String answer = null;
+
+            if ("agent".equals(currentTurn.getRole())) {
+                // 현재 턴이 AI(agent)인 경우 -> 질문으로 설정
+                question = currentTurn.getContent();
+
+                // 다음 턴이 존재하고, 그 턴이 사용자(user)인 경우 -> 답변으로 묶음
+                if (i + 1 < turns.size() && "user".equals(turns.get(i + 1).getRole())) {
+                    answer = turns.get(i + 1).getContent();
+                    i++; // 답변 턴을 '사용'했으므로 인덱스를 하나 건너뜁니다.
+                }
+            } else if ("user".equals(currentTurn.getRole())) {
+                // AI 질문 없이 사용자가 먼저 말을 시작한 예외적인 경우
+                answer = currentTurn.getContent();
+            }
+
+            // 하나의 InterviewRecord 객체로 생성 (질문과 답변이 한 쌍)
+            recordsToSave.add(InterviewRecord.builder()
                     .interviewSession(session)
                     .turnSequence(turnSequence++)
-                    .questionText(turn.getRole().equals("agent") ? turn.getContent() : null) // AI가 말한 거면 질문에
-                    .answerText(turn.getRole().equals("user") ? turn.getContent() : null)    // 사람이 말한 거면 답변에
-                    .build();
-            recordsToSave.add(record);
+                    .questionText(question)
+                    .answerText(answer)
+                    .build());
         }
 
         // 4. DB에 일괄 저장
-        if(!recordsToSave.isEmpty()) {
+        if (!recordsToSave.isEmpty()) {
             interviewRecordRepository.saveAll(recordsToSave);
-            log.info("✅ 대화 기록 DB 저장 완료! Session ID: {}, 저장된 Turn 수: {}", sessionId, recordsToSave.size());
+            log.info("✅ 대화 기록 DB 저장 완료! Session ID: {}, 저장된 레코드 수: {}", sessionId, recordsToSave.size());
         }
     }
 }

--- a/src/main/java/com/aibe/team2/domain/interview/service/InterviewRecordService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/InterviewRecordService.java
@@ -1,0 +1,59 @@
+package com.aibe.team2.domain.interview.service;
+
+import com.aibe.team2.domain.interview.dto.RetellWebhookRequest;
+import com.aibe.team2.domain.interview.entity.InterviewSession;
+import com.aibe.team2.domain.interview.repository.InterviewSessionRepository;
+import com.aibe.team2.domain.statistics.entity.InterviewRecord;
+import com.aibe.team2.domain.statistics.repository.interview.InterviewRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InterviewRecordService {
+
+    private final InterviewRecordRepository interviewRecordRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+
+    @Transactional
+    public void saveInterviewRecord(RetellWebhookRequest request) {
+        // 1. Session ID 추출
+        Map<String, Object> metadata = request.getCall().getMetadata();
+        if(metadata == null || !metadata.containsKey("session_id")) {
+            log.error("❌ 대화 기록 저장 실패: session_id가 존재하지 않습니다.");
+            return;
+        }
+        Long sessionId = Long.valueOf(metadata.get("session_id").toString());
+
+        // 2. 부모ㅓ 객체인 InterviewSession 조회
+        InterviewSession session = interviewSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 세션을 찾을 수 없습니다. : " + sessionId));
+
+        // 3. 대화 내역 추출 및 엔티티 변환
+        List<InterviewRecord> recordsToSave = new ArrayList<>();
+
+        int turnSequence = 1;
+        for (RetellWebhookRequest.TranscriptTurn turn : request.getCall().getTranscriptObject()) {
+            InterviewRecord record = InterviewRecord.builder()
+                    .interviewSession(session)
+                    .turnSequence(turnSequence++)
+                    .questionText(turn.getRole().equals("agent") ? turn.getContent() : null) // AI가 말한 거면 질문에
+                    .answerText(turn.getRole().equals("user") ? turn.getContent() : null)    // 사람이 말한 거면 답변에
+                    .build();
+            recordsToSave.add(record);
+        }
+
+        // 4. DB에 일괄 저장
+        if(!recordsToSave.isEmpty()) {
+            interviewRecordRepository.saveAll(recordsToSave);
+            log.info("✅ 대화 기록 DB 저장 완료! Session ID: {}, 저장된 Turn 수: {}", sessionId, recordsToSave.size());
+        }
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/interview/service/WebhookSqsConsumer.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/WebhookSqsConsumer.java
@@ -1,19 +1,20 @@
 package com.aibe.team2.domain.interview.service;
 
 import com.aibe.team2.domain.interview.dto.RetellWebhookRequest;
+import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
-// @Service 도메인 배포 및 Webhook 연동 전까지 임시 비활성화
+@Service
 @RequiredArgsConstructor
 public class WebhookSqsConsumer {
 
     private final WebhookService webhookService;
 
     // [NFR-PER-01] SQS Consumer (메시지 소비) WebhookController에서 발행한 메시지를 비동기로 받아 처리
-    // @SqsListener("${cloud.aws.sqs.webhook-queue-name:retell-webhook-queue}") // SQS 연동 시 주석 해제
+    @SqsListener("${cloud.aws.sqs.webhook-queue-name:retell-webhook-queue}") // SQS 연동 시 주석 해제
     public void consumeRetellWebhook(RetellWebhookRequest request) {
         log.info("📥 SQS Consumer: Retell Webhook 메시지 수신 완료 - Event: {}", request.getEvent());
 

--- a/src/main/java/com/aibe/team2/domain/interview/service/WebhookSqsConsumer.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/WebhookSqsConsumer.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 public class WebhookSqsConsumer {
 
     private final WebhookService webhookService;
+    private final InterviewRecordService interviewRecordService;
 
     // [NFR-PER-01] SQS Consumer (메시지 소비) WebhookController에서 발행한 메시지를 비동기로 받아 처리
     @SqsListener("${cloud.aws.sqs.webhook-queue-name:retell-webhook-queue}") // SQS 연동 시 주석 해제
@@ -20,5 +21,9 @@ public class WebhookSqsConsumer {
 
         // 리뷰 반영: 직접 처리하지 않고 공통 서비스로 위임 (DRY 원칙)
         webhookService.processRetellWebhook(request);
+
+        if("call_analyzed".equals(request.getEvent())) {
+            interviewRecordService.saveInterviewRecord(request);
+        }
     }
 }

--- a/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewRecord.java
+++ b/src/main/java/com/aibe/team2/domain/statistics/entity/InterviewRecord.java
@@ -101,6 +101,5 @@ public class InterviewRecord {
         this.feedbackText = feedbackText;
         this.evaluationScore = evaluationScore;
         this.responseTimeMs = responseTimeMs;
-        this.createdAt = LocalDateTime.now();
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #173

## 작업 내용
- 비동기 메시징 시스템을 활용한 면접 데이터 처리 파이프라인의 수신부와 영속성 계층 로직 완성
- SQS 메시지 소비: WebhookSqsConsumer를 구현하여 SQS 큐로부터 실시간으로 웹훅 페이로드를 수신하는 기능 활성화
- 비즈니스 로직 위임: 수신된 데이터를 직접 처리하지 않고 WebhookService로 위임하여 **관심사 분리**
- 대화 기록 일괄 저장: InterviewRecordService를 구현하여 면접 대화 내역(transcript_object)을 엔티티로 변환하고, saveAll()을 통해 DB에 효율적으로 일괄 저장
- 면접 상태 동기화: 면접 분석이 완료되면 해당 InterviewSession의 상태를 DONE으로 업데이트하는 로직 추

<br/>

## 변경 사항 및 주의 사항
- 환경 변수 추가: 웹훅 서명 검증을 위해 RETELL_WEBHOOK_KEY 설정이 필요합니다. 로컬 테스트를 위해 .env 파일에 해당 키를 추가해 주세요.
- 보안 검증 우회 (임시): 현재 로컬 테스트 편의를 위해 isValidSignature 로직은 항상 true를 반환하도록 우회되어 있습니다. 운영 환경 배포 전 반드시 활성화해야 합니다.
- 데이터 정합성: InterviewSession 데이터 삽입 시, DB 제약 조건에 따라 interview_mode는 NORMAL, FOLLOW_UP, STRESS 중 하나여야 하며, role은 ROLE_USER가 아닌 **MEMBER**로 입력해야 정상 작동합니다.
- Auditing 충돌 해결: InterviewRecord 엔티티 생성자에서 createdAt을 수동으로 할당하던 로직을 제거하여, JPA Auditing 기능과 충돌하지 않도록 수정했습니다.

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

