### PR TITLE
[FEAT] Ops Monitoring 기능 구현

### DIFF
--- a/db/init/001_init.sql
+++ b/db/init/001_init.sql
@@ -92,7 +92,7 @@ CREATE TABLE analysis_report (
                                  analysis_type VARCHAR(20) NOT NULL
                                      CHECK (analysis_type IN ('GENERAL', 'JOB_MATCHING')),
                                  status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
-                                     CHECK (status IN ('PENDING', 'PROCESSING', 'DELAYED', 'COMPLETED', 'FAILED')),
+                                     CHECK (status IN ('PENDING', 'PROCESSING', 'DELAYED', 'COMPLETED', 'FAILED', 'CANCELLED')),
                                  overall_feedback TEXT,
                                  sentence_corrections JSONB,
                                  generated_subtitle JSONB,
@@ -271,3 +271,27 @@ CREATE TABLE operation_metric_daily (
                                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                                         CONSTRAINT uk_operation_metric_daily UNIQUE (metric_date, service_type)
 );
+
+-- 15) operation_metric_hourly
+CREATE TABLE operation_metric_hourly (
+                                         id BIGSERIAL PRIMARY KEY,
+                                         metric_date DATE NOT NULL,
+                                         metric_hour INT NOT NULL,
+                                         service_type VARCHAR(50) NOT NULL,
+                                         total_log_count BIGINT NOT NULL DEFAULT 0,
+                                         total_token_usage BIGINT NOT NULL DEFAULT 0,
+                                         queue_enqueued_count BIGINT NOT NULL DEFAULT 0,
+                                         queue_success_count BIGINT NOT NULL DEFAULT 0,
+                                         queue_failed_count BIGINT NOT NULL DEFAULT 0,
+                                         error_count BIGINT NOT NULL DEFAULT 0,
+                                         failure_rate DOUBLE PRECISION NOT NULL DEFAULT 0,
+                                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                         CONSTRAINT uk_operation_metric_hourly UNIQUE (metric_date, metric_hour, service_type)
+);
+
+CREATE INDEX idx_operation_metric_hourly_date_hour
+    ON operation_metric_hourly(metric_date, metric_hour);
+
+CREATE INDEX idx_operation_metric_hourly_service
+    ON operation_metric_hourly(service_type);

--- a/src/main/java/com/aibe/team2/domain/admin/batch/OperationMetricHourlyScheduler.java
+++ b/src/main/java/com/aibe/team2/domain/admin/batch/OperationMetricHourlyScheduler.java
@@ -1,0 +1,31 @@
+package com.aibe.team2.domain.admin.batch;
+
+import com.aibe.team2.domain.admin.service.OperationMetricHourlyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OperationMetricHourlyScheduler {
+
+    private final OperationMetricHourlyService operationMetricHourlyService;
+
+    // 매시 5분에 직전 1시간 집계
+    @Scheduled(cron = "0 5 * * * *")
+    public void aggregatePreviousHour() {
+        LocalDateTime now = LocalDateTime.now().minusHours(1);
+
+        LocalDate targetDate = now.toLocalDate();
+        int targetHour = now.getHour();
+
+        log.info("운영 시간 단위 집계 시작 - date={}, hour={}", targetDate, targetHour);
+        operationMetricHourlyService.aggregateHourly(targetDate, targetHour);
+        log.info("운영 시간 단위 집계 완료 - date={}, hour={}", targetDate, targetHour);
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/admin/controller/AdminOperationControlController.java
+++ b/src/main/java/com/aibe/team2/domain/admin/controller/AdminOperationControlController.java
@@ -1,7 +1,9 @@
 package com.aibe.team2.domain.admin.controller;
 
+import com.aibe.team2.domain.admin.dto.request.AdminCancelRequest;
 import com.aibe.team2.domain.admin.dto.request.AdminRetryRequest;
 import com.aibe.team2.domain.admin.dto.response.AdminOperationControlResponse;
+import com.aibe.team2.domain.admin.dto.response.AdminOperationTargetDetailResponse;
 import com.aibe.team2.domain.admin.service.AdminOperationControlService;
 import com.aibe.team2.global.common.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -9,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @PreAuthorize("hasRole('ADMIN')")
 @RestController
@@ -36,6 +40,40 @@ public class AdminOperationControlController {
                                 "RETRY",
                                 "ACCEPTED"
                         )
+                )
+        );
+    }
+
+    @PostMapping("/cancel")
+    public ResponseEntity<ApiResponse<AdminOperationControlResponse>> cancel(
+            @RequestBody @Valid AdminCancelRequest request
+    ) {
+        adminOperationControlService.cancel(
+                request.getTargetType(),
+                request.getTargetId(),
+                request.getReason()
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        new AdminOperationControlResponse(
+                                request.getTargetType(),
+                                request.getTargetId(),
+                                "CANCEL",
+                                "ACCEPTED"
+                        )
+                )
+        );
+    }
+
+    @GetMapping("/target")
+    public ResponseEntity<ApiResponse<AdminOperationTargetDetailResponse>> getTargetDetail(
+            @RequestParam String targetType,
+            @RequestParam Long targetId
+    ) {
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        adminOperationControlService.getTargetDetail(targetType, targetId)
                 )
         );
     }

--- a/src/main/java/com/aibe/team2/domain/admin/controller/OpsMonitoringController.java
+++ b/src/main/java/com/aibe/team2/domain/admin/controller/OpsMonitoringController.java
@@ -1,0 +1,62 @@
+package com.aibe.team2.domain.admin.controller;
+
+import com.aibe.team2.domain.admin.dto.ops.OpsAlertResponse;
+import com.aibe.team2.domain.admin.dto.ops.OpsDashboardSummaryResponse;
+import com.aibe.team2.domain.admin.dto.ops.OpsQueueHourlyResponse;
+import com.aibe.team2.domain.admin.dto.ops.OpsQueueSummaryResponse;
+import com.aibe.team2.domain.admin.service.OpsMonitoringService;
+import com.aibe.team2.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@PreAuthorize("hasRole('ADMIN')")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ops")
+public class OpsMonitoringController {
+
+    private final OpsMonitoringService opsMonitoringService;
+
+    @GetMapping("/dashboard/summary")
+    public ResponseEntity<ApiResponse<OpsDashboardSummaryResponse>> getDashboardSummary() {
+        return ResponseEntity.ok(
+                ApiResponse.success(opsMonitoringService.getDashboardSummary())
+        );
+    }
+
+    @GetMapping("/alerts")
+    public ResponseEntity<ApiResponse<List<OpsAlertResponse>>> getAlerts() {
+        return ResponseEntity.ok(
+                ApiResponse.success(opsMonitoringService.getAlerts())
+        );
+    }
+
+    @GetMapping("/queue/summary")
+    public ResponseEntity<ApiResponse<OpsQueueSummaryResponse>> getQueueSummary() {
+        return ResponseEntity.ok(
+                ApiResponse.success(opsMonitoringService.getQueueSummary())
+        );
+    }
+
+    @GetMapping("/queue/hourly")
+    public ResponseEntity<ApiResponse<List<OpsQueueHourlyResponse>>> getQueueHourly(
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate date
+    ) {
+        LocalDate targetDate = (date == null) ? LocalDate.now() : date;
+
+        return ResponseEntity.ok(
+                ApiResponse.success(opsMonitoringService.getQueueHourly(targetDate))
+        );
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/admin/dto/ops/OpsAlertResponse.java
+++ b/src/main/java/com/aibe/team2/domain/admin/dto/ops/OpsAlertResponse.java
@@ -1,0 +1,16 @@
+package com.aibe.team2.domain.admin.dto.ops;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OpsAlertResponse {
+    private String alertType;
+    private String severity;
+    private String message;
+    private String targetType;
+    private Long targetId;
+}

--- a/src/main/java/com/aibe/team2/domain/admin/dto/ops/OpsDashboardSummaryResponse.java
+++ b/src/main/java/com/aibe/team2/domain/admin/dto/ops/OpsDashboardSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.aibe.team2.domain.admin.dto.ops;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OpsDashboardSummaryResponse {
+    private long todayErrorCount;
+    private long todayQueueEnqueuedCount;
+    private long todayQueueSuccessCount;
+    private long todayQueueFailedCount;
+    private double todayQueueSuccessRate;
+    private long unresolvedIssueCount;
+}

--- a/src/main/java/com/aibe/team2/domain/admin/dto/ops/OpsQueueHourlyResponse.java
+++ b/src/main/java/com/aibe/team2/domain/admin/dto/ops/OpsQueueHourlyResponse.java
@@ -1,0 +1,15 @@
+package com.aibe.team2.domain.admin.dto.ops;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OpsQueueHourlyResponse {
+    private String hour;
+    private long enqueuedCount;
+    private long successCount;
+    private long failedCount;
+}

--- a/src/main/java/com/aibe/team2/domain/admin/dto/ops/OpsQueueSummaryResponse.java
+++ b/src/main/java/com/aibe/team2/domain/admin/dto/ops/OpsQueueSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.aibe.team2.domain.admin.dto.ops;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OpsQueueSummaryResponse {
+    private long enqueuedCount;
+    private long processingCount;
+    private long successCount;
+    private long failedCount;
+    private long cancelledCount;
+    private double successRate;
+}

--- a/src/main/java/com/aibe/team2/domain/admin/dto/request/AdminCancelRequest.java
+++ b/src/main/java/com/aibe/team2/domain/admin/dto/request/AdminCancelRequest.java
@@ -1,0 +1,17 @@
+package com.aibe.team2.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class AdminCancelRequest {
+
+    @NotBlank
+    private String targetType;
+
+    @NotNull
+    private Long targetId;
+
+    private String reason;
+}

--- a/src/main/java/com/aibe/team2/domain/admin/dto/response/AdminOperationTargetDetailResponse.java
+++ b/src/main/java/com/aibe/team2/domain/admin/dto/response/AdminOperationTargetDetailResponse.java
@@ -1,0 +1,28 @@
+package com.aibe.team2.domain.admin.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminOperationTargetDetailResponse {
+    private String targetType;
+    private Long targetId;
+
+    private String currentStatus;
+    private String latestQueueStatus;
+    private Integer retryCount;
+    private String latestErrorMessage;
+    private LocalDateTime lastProcessedAt;
+
+    private Long memberId;
+    private String memberEmail;
+    private String memberNickname;
+
+    private boolean retryable;
+    private boolean cancellable;
+}

--- a/src/main/java/com/aibe/team2/domain/admin/entity/OperationMetricHourly.java
+++ b/src/main/java/com/aibe/team2/domain/admin/entity/OperationMetricHourly.java
@@ -1,0 +1,121 @@
+package com.aibe.team2.domain.admin.entity;
+
+import com.aibe.team2.domain.statistics.enums.ServiceType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "operation_metric_hourly",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_operation_metric_hourly",
+                        columnNames = {"metric_date", "metric_hour", "service_type"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class OperationMetricHourly {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "metric_date", nullable = false)
+    private LocalDate metricDate;
+
+    @Column(name = "metric_hour", nullable = false)
+    private Integer metricHour;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "service_type", nullable = false, length = 50)
+    private ServiceType serviceType;
+
+    @Column(name = "total_log_count", nullable = false)
+    private Long totalLogCount;
+
+    @Column(name = "total_token_usage", nullable = false)
+    private Long totalTokenUsage;
+
+    @Column(name = "queue_enqueued_count", nullable = false)
+    private Long queueEnqueuedCount;
+
+    @Column(name = "queue_success_count", nullable = false)
+    private Long queueSuccessCount;
+
+    @Column(name = "queue_failed_count", nullable = false)
+    private Long queueFailedCount;
+
+    @Column(name = "error_count", nullable = false)
+    private Long errorCount;
+
+    @Column(name = "failure_rate", nullable = false)
+    private Double failureRate;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private OperationMetricHourly(
+            LocalDate metricDate,
+            Integer metricHour,
+            ServiceType serviceType,
+            Long totalLogCount,
+            Long totalTokenUsage,
+            Long queueEnqueuedCount,
+            Long queueSuccessCount,
+            Long queueFailedCount,
+            Long errorCount,
+            Double failureRate
+    ) {
+        this.metricDate = metricDate;
+        this.metricHour = metricHour;
+        this.serviceType = serviceType;
+        this.totalLogCount = totalLogCount;
+        this.totalTokenUsage = totalTokenUsage;
+        this.queueEnqueuedCount = queueEnqueuedCount;
+        this.queueSuccessCount = queueSuccessCount;
+        this.queueFailedCount = queueFailedCount;
+        this.errorCount = errorCount;
+        this.failureRate = failureRate;
+    }
+
+    public static OperationMetricHourly create(
+            LocalDate metricDate,
+            Integer metricHour,
+            ServiceType serviceType,
+            Long totalLogCount,
+            Long totalTokenUsage,
+            Long queueEnqueuedCount,
+            Long queueSuccessCount,
+            Long queueFailedCount,
+            Long errorCount,
+            Double failureRate
+    ) {
+        return OperationMetricHourly.builder()
+                .metricDate(metricDate)
+                .metricHour(metricHour)
+                .serviceType(serviceType)
+                .totalLogCount(totalLogCount)
+                .totalTokenUsage(totalTokenUsage)
+                .queueEnqueuedCount(queueEnqueuedCount)
+                .queueSuccessCount(queueSuccessCount)
+                .queueFailedCount(queueFailedCount)
+                .errorCount(errorCount)
+                .failureRate(failureRate)
+                .build();
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/admin/repository/OperationMetricHourlyRepository.java
+++ b/src/main/java/com/aibe/team2/domain/admin/repository/OperationMetricHourlyRepository.java
@@ -1,0 +1,25 @@
+package com.aibe.team2.domain.admin.repository;
+
+import com.aibe.team2.domain.admin.entity.OperationMetricHourly;
+import com.aibe.team2.domain.statistics.enums.ServiceType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface OperationMetricHourlyRepository extends JpaRepository<OperationMetricHourly, Long> {
+
+    Optional<OperationMetricHourly> findByMetricDateAndMetricHourAndServiceType(
+            LocalDate metricDate,
+            Integer metricHour,
+            ServiceType serviceType
+    );
+
+    List<OperationMetricHourly> findAllByMetricDateOrderByMetricHourAsc(LocalDate metricDate);
+
+    List<OperationMetricHourly> findAllByMetricDateAndServiceTypeOrderByMetricHourAsc(
+            LocalDate metricDate,
+            ServiceType serviceType
+    );
+}

--- a/src/main/java/com/aibe/team2/domain/admin/repository/QueueJobMetricRepository.java
+++ b/src/main/java/com/aibe/team2/domain/admin/repository/QueueJobMetricRepository.java
@@ -19,5 +19,13 @@ public interface QueueJobMetricRepository extends JpaRepository<QueueJobMetric, 
 
     long countByTargetTypeAndTargetIdAndStatus(String targetType, Long targetId, QueueJobStatus status);
 
+    long countByStatus(QueueJobStatus status);
+
+    long countByStatusAndCreatedAtBetween(
+            QueueJobStatus status,
+            LocalDateTime start,
+            LocalDateTime end
+    );
+
     Optional<QueueJobMetric> findTopByTargetTypeAndTargetIdOrderByCreatedAtDesc(String targetType, Long targetId);
 }

--- a/src/main/java/com/aibe/team2/domain/admin/service/AdminOperationControlService.java
+++ b/src/main/java/com/aibe/team2/domain/admin/service/AdminOperationControlService.java
@@ -1,6 +1,13 @@
 package com.aibe.team2.domain.admin.service;
 
+import com.aibe.team2.domain.admin.dto.response.AdminOperationTargetDetailResponse;
+import com.aibe.team2.domain.admin.entity.QueueJobMetric;
+import com.aibe.team2.domain.admin.enums.QueueJobStatus;
 import com.aibe.team2.domain.admin.repository.QueueJobMetricRepository;
+import com.aibe.team2.domain.error.entity.ErrorLog;
+import com.aibe.team2.domain.error.repository.ErrorLogRepository;
+import com.aibe.team2.domain.mypage.entity.Member;
+import com.aibe.team2.domain.mypage.repository.member.MemberRepository;
 import com.aibe.team2.domain.resume.dto.AnalysisEvent;
 import com.aibe.team2.domain.resume.entity.AnalysisStatus;
 import com.aibe.team2.domain.resume.entity.AnalyzedReport;
@@ -13,6 +20,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -20,6 +29,8 @@ public class AdminOperationControlService {
 
     private final ResumeAnalysisRepository resumeAnalysisRepository;
     private final QueueJobMetricRepository queueJobMetricRepository;
+    private final ErrorLogRepository errorLogRepository;
+    private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -34,12 +45,25 @@ public class AdminOperationControlService {
         throw new BusinessException(ErrorCode.COMMON_400);
     }
 
+    @Transactional
+    public void cancel(String targetType, Long targetId, String reason) {
+        log.info("관리자 취소 요청: targetType={}, targetId={}, reason={}", targetType, targetId, reason);
+
+        if ("ANALYSIS_REPORT".equalsIgnoreCase(targetType)) {
+            cancelAnalysisReport(targetId, reason);
+            return;
+        }
+
+        throw new BusinessException(ErrorCode.COMMON_400);
+    }
+
     private void retryAnalysisReport(Long reportId) {
         AnalyzedReport report = resumeAnalysisRepository.findById(reportId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ANALYSIS_REPORT_NOT_FOUND));
 
-        if (report.getStatus() != AnalysisStatus.FAILED &&
-                report.getStatus() != AnalysisStatus.DELAYED) {
+        if (report.getStatus() != AnalysisStatus.FAILED
+                && report.getStatus() != AnalysisStatus.DELAYED
+                && report.getStatus() != AnalysisStatus.CANCELLED) {
             throw new BusinessException(ErrorCode.COMMON_409);
         }
 
@@ -57,5 +81,94 @@ public class AdminOperationControlService {
                         newRetryCount
                 )
         );
+    }
+
+    private void cancelAnalysisReport(Long reportId, String reason) {
+        AnalyzedReport report = resumeAnalysisRepository.findById(reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ANALYSIS_REPORT_NOT_FOUND));
+
+        QueueJobMetric latestMetric = queueJobMetricRepository
+                .findTopByTargetTypeAndTargetIdOrderByCreatedAtDesc("ANALYSIS_REPORT", reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COMMON_404));
+
+        if (latestMetric.getStatus() == QueueJobStatus.PROCESSING) {
+            throw new BusinessException(ErrorCode.COMMON_409);
+        }
+
+        if (latestMetric.getStatus() == QueueJobStatus.SUCCESS
+                || latestMetric.getStatus() == QueueJobStatus.FAILED
+                || latestMetric.getStatus() == QueueJobStatus.CANCELLED) {
+            throw new BusinessException(ErrorCode.COMMON_409);
+        }
+
+        latestMetric.markCancelled(
+                reason == null || reason.isBlank() ? "관리자 취소 요청" : reason
+        );
+
+        report.updateStatus(AnalysisStatus.CANCELLED);
+    }
+
+    @Transactional(readOnly = true)
+    public AdminOperationTargetDetailResponse getTargetDetail(String targetType, Long targetId) {
+        if ("ANALYSIS_REPORT".equalsIgnoreCase(targetType)) {
+            return getAnalysisReportDetail(targetId);
+        }
+
+        throw new BusinessException(ErrorCode.COMMON_400);
+    }
+
+    private AdminOperationTargetDetailResponse getAnalysisReportDetail(Long reportId) {
+        AnalyzedReport report = resumeAnalysisRepository.findById(reportId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ANALYSIS_REPORT_NOT_FOUND));
+
+        QueueJobMetric latestMetric = queueJobMetricRepository
+                .findTopByTargetTypeAndTargetIdOrderByCreatedAtDesc("ANALYSIS_REPORT", reportId)
+                .orElse(null);
+
+        ErrorLog latestErrorLog = errorLogRepository
+                .findTopByTargetTypeAndTargetIdOrderByOccurredAtDesc("ANALYSIS_REPORT", reportId)
+                .orElse(null);
+
+        String latestQueueStatus = latestMetric != null ? latestMetric.getStatus().name() : null;
+        Integer retryCount = latestMetric != null ? latestMetric.getRetryCount() : 0;
+        String latestErrorMessage = latestErrorLog != null ? latestErrorLog.getMessage() : null;
+        LocalDateTime lastProcessedAt = latestMetric != null ? latestMetric.getUpdatedAt() : null;
+
+        Long memberId = report.getResume() != null ? report.getResume().getMemberId() : null;
+        String memberEmail = null;
+        String memberNickname = null;
+
+        if (memberId != null) {
+            Member member = memberRepository.findById(memberId).orElse(null);
+            if (member != null) {
+                memberEmail = member.getEmail();
+                memberNickname = member.getNickname();
+            }
+        }
+
+        boolean retryable = report.getStatus() == AnalysisStatus.FAILED
+                || report.getStatus() == AnalysisStatus.DELAYED
+                || report.getStatus() == AnalysisStatus.CANCELLED;
+
+        boolean cancellable = latestMetric != null
+                && latestMetric.getStatus() != QueueJobStatus.PROCESSING
+                && latestMetric.getStatus() != QueueJobStatus.SUCCESS
+                && latestMetric.getStatus() != QueueJobStatus.FAILED
+                && latestMetric.getStatus() != QueueJobStatus.CANCELLED;
+
+        return AdminOperationTargetDetailResponse.builder()
+                .targetType("ANALYSIS_REPORT")
+                .targetId(reportId)
+                .currentStatus(report.getStatus().name())
+                .latestQueueStatus(latestQueueStatus)
+                .retryCount(retryCount)
+                .latestErrorMessage(latestErrorMessage)
+                .lastProcessedAt(lastProcessedAt)
+                .memberId(memberId)
+                .memberEmail(memberEmail)
+                .memberNickname(memberNickname)
+                .retryable(retryable)
+                .cancellable(cancellable)
+                .build();
     }
 }

--- a/src/main/java/com/aibe/team2/domain/admin/service/OperationMetricHourlyService.java
+++ b/src/main/java/com/aibe/team2/domain/admin/service/OperationMetricHourlyService.java
@@ -1,0 +1,98 @@
+package com.aibe.team2.domain.admin.service;
+
+import com.aibe.team2.domain.admin.entity.OperationMetricHourly;
+import com.aibe.team2.domain.admin.enums.QueueJobStatus;
+import com.aibe.team2.domain.admin.repository.OperationMetricHourlyRepository;
+import com.aibe.team2.domain.admin.repository.QueueJobMetricRepository;
+import com.aibe.team2.domain.error.enums.ErrorDomain;
+import com.aibe.team2.domain.error.repository.ErrorLogRepository;
+import com.aibe.team2.domain.statistics.enums.ServiceType;
+import com.aibe.team2.domain.statistics.repository.usage.UsageLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OperationMetricHourlyService {
+
+    private final OperationMetricHourlyRepository operationMetricHourlyRepository;
+    private final UsageLogRepository usageLogRepository;
+    private final QueueJobMetricRepository queueJobMetricRepository;
+    private final ErrorLogRepository errorLogRepository;
+
+    @Transactional
+    public void aggregateHourly(LocalDate targetDate, int targetHour) {
+        LocalDateTime start = targetDate.atTime(targetHour, 0);
+        LocalDateTime end = start.plusHours(1);
+
+        for (ServiceType serviceType : List.of(ServiceType.RESUME, ServiceType.INTERVIEW, ServiceType.ADMIN)) {
+            long totalLogCount =
+                    usageLogRepository.countByServiceTypeAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                            serviceType, start, end
+                    );
+
+            Long totalTokenUsage =
+                    usageLogRepository.sumTokenUsageByServiceTypeAndCreatedAtRange(
+                            serviceType, start, end
+                    );
+
+            ErrorDomain errorDomain = mapServiceTypeToErrorDomain(serviceType);
+            long errorCount =
+                    errorLogRepository.countByErrorDomainAndOccurredAtBetween(
+                            errorDomain, start, end
+                    );
+
+            long queueEnqueuedCount = serviceType == ServiceType.RESUME
+                    ? queueJobMetricRepository.countByStatusAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                    QueueJobStatus.ENQUEUED, start, end
+            )
+                    : 0L;
+
+            long queueSuccessCount = serviceType == ServiceType.RESUME
+                    ? queueJobMetricRepository.countByStatusAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                    QueueJobStatus.SUCCESS, start, end
+            )
+                    : 0L;
+
+            long queueFailedCount = serviceType == ServiceType.RESUME
+                    ? queueJobMetricRepository.countByStatusAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+                    QueueJobStatus.FAILED, start, end
+            )
+                    : 0L;
+
+            double failureRate = queueEnqueuedCount == 0
+                    ? 0.0
+                    : (double) queueFailedCount / queueEnqueuedCount;
+
+            operationMetricHourlyRepository.findByMetricDateAndMetricHourAndServiceType(
+                    targetDate, targetHour, serviceType
+            ).orElseGet(() -> operationMetricHourlyRepository.save(
+                    OperationMetricHourly.create(
+                            targetDate,
+                            targetHour,
+                            serviceType,
+                            totalLogCount,
+                            totalTokenUsage == null ? 0L : totalTokenUsage,
+                            queueEnqueuedCount,
+                            queueSuccessCount,
+                            queueFailedCount,
+                            errorCount,
+                            failureRate
+                    )
+            ));
+        }
+    }
+
+    private ErrorDomain mapServiceTypeToErrorDomain(ServiceType serviceType) {
+        return switch (serviceType) {
+            case RESUME -> ErrorDomain.RESUME;
+            case INTERVIEW -> ErrorDomain.INTERVIEW;
+            case ADMIN -> ErrorDomain.ADMIN;
+        };
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/admin/service/OpsMonitoringService.java
+++ b/src/main/java/com/aibe/team2/domain/admin/service/OpsMonitoringService.java
@@ -1,0 +1,136 @@
+package com.aibe.team2.domain.admin.service;
+
+import com.aibe.team2.domain.admin.dto.ops.OpsAlertResponse;
+import com.aibe.team2.domain.admin.dto.ops.OpsDashboardSummaryResponse;
+import com.aibe.team2.domain.admin.dto.ops.OpsQueueHourlyResponse;
+import com.aibe.team2.domain.admin.dto.ops.OpsQueueSummaryResponse;
+import com.aibe.team2.domain.admin.enums.QueueJobStatus;
+import com.aibe.team2.domain.admin.repository.QueueJobMetricRepository;
+import com.aibe.team2.domain.error.enums.IssueStatus;
+import com.aibe.team2.domain.error.repository.ErrorIssueRepository;
+import com.aibe.team2.domain.error.repository.ErrorLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OpsMonitoringService {
+
+    private final QueueJobMetricRepository queueJobMetricRepository;
+    private final ErrorLogRepository errorLogRepository;
+    private final ErrorIssueRepository errorIssueRepository;
+
+    @Value("${app.error.alert.occurrence-threshold:10}")
+    private long alertThreshold;
+
+    @Transactional(readOnly = true)
+    public OpsDashboardSummaryResponse getDashboardSummary() {
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+
+        long todayErrorCount = errorLogRepository.countByOccurredAtBetween(start, end);
+        long todayQueueEnqueuedCount = queueJobMetricRepository.countByStatusAndCreatedAtBetween(QueueJobStatus.ENQUEUED, start, end);
+        long todayQueueSuccessCount = queueJobMetricRepository.countByStatusAndCreatedAtBetween(QueueJobStatus.SUCCESS, start, end);
+        long todayQueueFailedCount = queueJobMetricRepository.countByStatusAndCreatedAtBetween(QueueJobStatus.FAILED, start, end);
+
+        long totalDone = todayQueueSuccessCount + todayQueueFailedCount;
+        double successRate = totalDone == 0 ? 0.0 : (todayQueueSuccessCount * 100.0 / totalDone);
+
+        long unresolvedIssueCount = errorIssueRepository.countByStatus(IssueStatus.OPEN);
+
+        return OpsDashboardSummaryResponse.builder()
+                .todayErrorCount(todayErrorCount)
+                .todayQueueEnqueuedCount(todayQueueEnqueuedCount)
+                .todayQueueSuccessCount(todayQueueSuccessCount)
+                .todayQueueFailedCount(todayQueueFailedCount)
+                .todayQueueSuccessRate(successRate)
+                .unresolvedIssueCount(unresolvedIssueCount)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OpsAlertResponse> getAlerts() {
+        List<OpsAlertResponse> alerts = new ArrayList<>();
+
+        LocalDateTime start = LocalDate.now().atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+
+        long failedCount = queueJobMetricRepository.countByStatusAndCreatedAtBetween(
+                QueueJobStatus.FAILED, start, end
+        );
+
+        if (failedCount >= alertThreshold) {
+            alerts.add(OpsAlertResponse.builder()
+                    .alertType("QUEUE_FAILURE")
+                    .severity("HIGH")
+                    .message("오늘 실패한 큐 작업이 임계치 이상입니다. failedCount=" + failedCount)
+                    .targetType("QUEUE_JOB")
+                    .targetId(null)
+                    .build());
+        }
+
+        long openIssueCount = errorIssueRepository.countByStatus(IssueStatus.OPEN);
+        if (openIssueCount >= alertThreshold) {
+            alerts.add(OpsAlertResponse.builder()
+                    .alertType("OPEN_ERROR_ISSUE")
+                    .severity("MEDIUM")
+                    .message("미해결 에러 이슈가 임계치 이상입니다. openIssueCount=" + openIssueCount)
+                    .targetType("ERROR_ISSUE")
+                    .targetId(null)
+                    .build());
+        }
+
+        return alerts;
+    }
+
+    @Transactional(readOnly = true)
+    public OpsQueueSummaryResponse getQueueSummary() {
+        long enqueued = queueJobMetricRepository.countByStatus(QueueJobStatus.ENQUEUED);
+        long processing = queueJobMetricRepository.countByStatus(QueueJobStatus.PROCESSING);
+        long success = queueJobMetricRepository.countByStatus(QueueJobStatus.SUCCESS);
+        long failed = queueJobMetricRepository.countByStatus(QueueJobStatus.FAILED);
+        long cancelled = queueJobMetricRepository.countByStatus(QueueJobStatus.CANCELLED);
+
+        long totalDone = success + failed + cancelled;
+        double successRate = totalDone == 0 ? 0.0 : (success * 100.0 / totalDone);
+
+        return OpsQueueSummaryResponse.builder()
+                .enqueuedCount(enqueued)
+                .processingCount(processing)
+                .successCount(success)
+                .failedCount(failed)
+                .cancelledCount(cancelled)
+                .successRate(successRate)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<OpsQueueHourlyResponse> getQueueHourly(LocalDate date) {
+        List<OpsQueueHourlyResponse> result = new ArrayList<>();
+
+        for (int i = 0; i < 24; i++) {
+            LocalDateTime start = date.atTime(i, 0);
+            LocalDateTime end = start.plusHours(1);
+
+            long enqueued = queueJobMetricRepository.countByStatusAndCreatedAtBetween(QueueJobStatus.ENQUEUED, start, end);
+            long success = queueJobMetricRepository.countByStatusAndCreatedAtBetween(QueueJobStatus.SUCCESS, start, end);
+            long failed = queueJobMetricRepository.countByStatusAndCreatedAtBetween(QueueJobStatus.FAILED, start, end);
+
+            result.add(OpsQueueHourlyResponse.builder()
+                    .hour(String.format("%02d:00", i))
+                    .enqueuedCount(enqueued)
+                    .successCount(success)
+                    .failedCount(failed)
+                    .build());
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/aibe/team2/domain/auth/util/JwtTokenProvider.java
@@ -74,7 +74,8 @@ public class JwtTokenProvider {
         try {
             Jwts.parser()
                     .setSigningKey(key)
-                    .parseClaimsJwt(token);     // 서명이나 만료 시간에 문제가 있으면 예외 발생
+                    .parseClaimsJws(token);   // 서명이나 만료 시간에 문제가 있으면 예외 발생
+                    //.parseClaimsJwt(token); 401에러 해결을 위해 Jws로 수정함.
             return true;
         } catch (io.jsonwebtoken.security.SignatureException e) {
             System.out.println("잘못된 JWT 서명입니다.");

--- a/src/main/java/com/aibe/team2/domain/error/controller/ErrorAdminController.java
+++ b/src/main/java/com/aibe/team2/domain/error/controller/ErrorAdminController.java
@@ -1,6 +1,11 @@
 package com.aibe.team2.domain.error.controller;
 
-import com.aibe.team2.domain.error.dto.admin.*;
+import com.aibe.team2.domain.error.dto.admin.ErrorIssueDetailResponse;
+import com.aibe.team2.domain.error.dto.admin.ErrorIssueResponse;
+import com.aibe.team2.domain.error.dto.admin.ErrorIssueSearchCond;
+import com.aibe.team2.domain.error.dto.admin.ErrorIssueStatusUpdateRequest;
+import com.aibe.team2.domain.error.dto.admin.ErrorLogDetailResponse;
+import com.aibe.team2.domain.error.dto.admin.ErrorLogRowResponse;
 import com.aibe.team2.domain.error.enums.IssueStatus;
 import com.aibe.team2.domain.error.service.ErrorAdminService;
 import com.aibe.team2.global.common.response.ApiResponse;
@@ -31,7 +36,7 @@ public class ErrorAdminController {
     }
 
     @GetMapping("/{issueId}")
-    public ResponseEntity<ApiResponse<ErrorIssueResponse>> getIssueDetail(
+    public ResponseEntity<ApiResponse<ErrorIssueDetailResponse>> getIssueDetail(
             @PathVariable Long issueId
     ) {
         return ResponseEntity.ok(ApiResponse.success(

--- a/src/main/java/com/aibe/team2/domain/error/dto/admin/ErrorIssueDetailResponse.java
+++ b/src/main/java/com/aibe/team2/domain/error/dto/admin/ErrorIssueDetailResponse.java
@@ -1,0 +1,62 @@
+package com.aibe.team2.domain.error.dto.admin;
+
+import com.aibe.team2.domain.error.entity.ErrorIssue;
+import com.aibe.team2.domain.error.enums.ErrorDomain;
+import com.aibe.team2.domain.error.enums.ErrorSeverity;
+import com.aibe.team2.domain.error.enums.IssueStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorIssueDetailResponse {
+
+    private final Long issueId;
+    private final String fingerprint;
+    private final String title;
+    private final String errorCode;
+    private final ErrorSeverity severity;
+    private final IssueStatus status;
+    private final ErrorDomain errorDomain;
+    private final Long occurrenceCount;
+    private final LocalDateTime firstOccurredAt;
+    private final LocalDateTime lastOccurredAt;
+    private final Long lastErrorLogId;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    private final String targetType;
+    private final Long targetId;
+    private final Long memberId;
+    private final String memberEmail;
+    private final String memberNickname;
+
+    public ErrorIssueDetailResponse(
+            ErrorIssue issue,
+            String targetType,
+            Long targetId,
+            Long memberId,
+            String memberEmail,
+            String memberNickname
+    ) {
+        this.issueId = issue.getId();
+        this.fingerprint = issue.getFingerprint();
+        this.title = issue.getTitle();
+        this.errorCode = issue.getErrorCode();
+        this.severity = issue.getSeverity();
+        this.status = issue.getStatus();
+        this.errorDomain = issue.getErrorDomain();
+        this.occurrenceCount = issue.getOccurrenceCount();
+        this.firstOccurredAt = issue.getFirstOccurredAt();
+        this.lastOccurredAt = issue.getLastOccurredAt();
+        this.lastErrorLogId = issue.getLastErrorLogId();
+        this.createdAt = issue.getCreatedAt();
+        this.updatedAt = issue.getUpdatedAt();
+
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.memberId = memberId;
+        this.memberEmail = memberEmail;
+        this.memberNickname = memberNickname;
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/error/repository/ErrorIssueRepository.java
+++ b/src/main/java/com/aibe/team2/domain/error/repository/ErrorIssueRepository.java
@@ -32,4 +32,6 @@ public interface ErrorIssueRepository extends JpaRepository<ErrorIssue, Long>, E
             ErrorDomain errorDomain,
             Pageable pageable
     );
+
+    long countByStatus(IssueStatus status);
 }

--- a/src/main/java/com/aibe/team2/domain/error/repository/ErrorLogRepository.java
+++ b/src/main/java/com/aibe/team2/domain/error/repository/ErrorLogRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface ErrorLogRepository extends JpaRepository<ErrorLog, Long> {
 
@@ -35,6 +36,10 @@ public interface ErrorLogRepository extends JpaRepository<ErrorLog, Long> {
             LocalDateTime start,
             LocalDateTime end
     );
+
+    Optional<ErrorLog> findTopByTargetTypeAndTargetIdOrderByOccurredAtDesc(String targetType, Long targetId);
+
+    Optional<ErrorLog> findTopByIssueIdOrderByOccurredAtDesc(Long issueId);
 
     @Modifying
     @Query("delete from ErrorLog e where e.occurredAt < :threshold")

--- a/src/main/java/com/aibe/team2/domain/error/service/ErrorAdminService.java
+++ b/src/main/java/com/aibe/team2/domain/error/service/ErrorAdminService.java
@@ -1,13 +1,16 @@
 package com.aibe.team2.domain.error.service;
 
+import com.aibe.team2.domain.error.dto.admin.ErrorIssueDetailResponse;
 import com.aibe.team2.domain.error.dto.admin.ErrorIssueResponse;
 import com.aibe.team2.domain.error.dto.admin.ErrorIssueSearchCond;
 import com.aibe.team2.domain.error.dto.admin.ErrorLogDetailResponse;
 import com.aibe.team2.domain.error.dto.admin.ErrorLogRowResponse;
 import com.aibe.team2.domain.error.entity.ErrorIssue;
+import com.aibe.team2.domain.error.entity.ErrorLog;
 import com.aibe.team2.domain.error.enums.IssueStatus;
 import com.aibe.team2.domain.error.repository.ErrorIssueRepository;
 import com.aibe.team2.domain.error.repository.ErrorLogRepository;
+import com.aibe.team2.domain.mypage.entity.Member;
 import com.aibe.team2.global.error.ErrorCode;
 import com.aibe.team2.global.exception.custom.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -28,16 +31,47 @@ public class ErrorAdminService {
         return errorIssueRepository.search(cond, pageable)
                 .map(ErrorIssueResponse::new);
     }
-    public ErrorIssueResponse getIssueDetail(Long issueId) {
+
+    public ErrorIssueDetailResponse getIssueDetail(Long issueId) {
         ErrorIssue issue = errorIssueRepository.findById(issueId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.COMMON_404));
-        return new ErrorIssueResponse(issue);
+
+        ErrorLog latestLog = errorLogRepository.findTopByIssueIdOrderByOccurredAtDesc(issueId)
+                .orElse(null);
+
+        String targetType = null;
+        Long targetId = null;
+        Long memberId = null;
+        String memberEmail = null;
+        String memberNickname = null;
+
+        if (latestLog != null) {
+            targetType = latestLog.getTargetType();
+            targetId = latestLog.getTargetId();
+
+            Member member = latestLog.getMember();
+            if (member != null) {
+                memberId = member.getMemberId();
+                memberEmail = member.getEmail();
+                memberNickname = member.getNickname();
+            }
+        }
+
+        return new ErrorIssueDetailResponse(
+                issue,
+                targetType,
+                targetId,
+                memberId,
+                memberEmail,
+                memberNickname
+        );
     }
 
     public Page<ErrorLogRowResponse> getLogsByIssue(Long issueId, Pageable pageable) {
         return errorLogRepository.findByIssueId(issueId, pageable)
                 .map(ErrorLogRowResponse::new);
     }
+
     public ErrorLogDetailResponse getLogDetail(Long logId) {
         return errorLogRepository.findById(logId)
                 .map(ErrorLogDetailResponse::new)

--- a/src/main/java/com/aibe/team2/domain/resume/entity/AnalysisStatus.java
+++ b/src/main/java/com/aibe/team2/domain/resume/entity/AnalysisStatus.java
@@ -5,5 +5,6 @@ public enum AnalysisStatus {
     PROCESSING,   // 처리
     DELAYED,      // 지연
     COMPLETED,    // 완료
-    FAILED        // 실패
+    FAILED,        // 실패
+    CANCELLED
 }

--- a/src/main/java/com/aibe/team2/global/config/SecurityConfig.java
+++ b/src/main/java/com/aibe/team2/global/config/SecurityConfig.java
@@ -1,16 +1,17 @@
 package com.aibe.team2.global.config;
 
 import com.aibe.team2.domain.auth.filter.JwtAuthenticationFilter;
+import com.aibe.team2.domain.auth.filter.OAuth2SuccessHandler;
 import com.aibe.team2.domain.auth.service.CustomMemberDetailService;
 import com.aibe.team2.domain.auth.service.CustomOAuth2UserService;
 import com.aibe.team2.domain.auth.util.JwtTokenProvider;
-import com.aibe.team2.domain.auth.filter.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -19,9 +20,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
-
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 


### PR DESCRIPTION
## 관련 이슈
- closed: #180 

## 작업 내용
1. Ops Monitoring
운영 상태 조회 API (OpsMonitoringController)
큐 상태, 작업 처리 현황 조회 기능

2. Metric 집계
시간 단위 메트릭 저장 (OperationMetricHourly)
처리량, 성공/실패 등 통계 관리

3. 운영 제어 기능
작업 재시도 (retry)
작업 취소 (cancel)
AdminOperationControlService 기반 처리

4. 에러 관리 확장
ErrorAdminController / Service 개선
ErrorIssue / ErrorLog 조회 기능 강화

5. 보안 및 인증 보완
JwtTokenProvider 수정
SecurityConfig 개선

<br/>


## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
