### PR TITLE
[FIX] 텍스트 면접 면접관 답변이 빈칸으로 나오던 현상 수정 완료

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -19,6 +19,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import com.aibe.team2.domain.auth.dto.CustomUserDetails;
 
 @RestController
 @RequestMapping("/api/interviews")
@@ -148,14 +149,18 @@ public class InterviewController {
         return session;
     }
 
-    /**
-     * UserDetails에서 MemberId 추출을 돕는 유틸 메서드
-     */
+    // UserDetails에서 MemberId 추출을 돕는 유틸 메서드
     private Long getMemberIdFromUserDetails(UserDetails userDetails) {
+        // 1. CustomUserDetails로 형변환하여 실제 Member 엔티티의 ID(PK)를 안전하게 가져옴
+        if (userDetails instanceof CustomUserDetails customUserDetails) {
+            return customUserDetails.getMember().getMemberId();
+        }
+
+        // 2. 예외 상황에 대한 폴백(Fallback) 처리
         try {
             return Long.valueOf(userDetails.getUsername());
         } catch (NumberFormatException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "회원 식별자를 처리할 수 없습니다.");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "회원 식별자 형식이 올바르지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/aibe/team2/domain/log/filter/LoggingFilter.java
+++ b/src/main/java/com/aibe/team2/domain/log/filter/LoggingFilter.java
@@ -99,6 +99,6 @@ public class LoggingFilter extends OncePerRequestFilter {
         return path.startsWith("/error") ||
                 path.startsWith("/favicon.ico") ||
                 path.startsWith("/api/v1/admin/logs") ||
-                path.contains("/stream"); // 작성자 최원준
+                path.endsWith("/stream");
     }
 }

--- a/src/main/java/com/aibe/team2/domain/log/filter/LoggingFilter.java
+++ b/src/main/java/com/aibe/team2/domain/log/filter/LoggingFilter.java
@@ -94,6 +94,11 @@ public class LoggingFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
         // /error 경로나 정적 리소스는 로그 대상에서 제외하여 무한 루프 방지
-        return path.startsWith("/error") || path.startsWith("/favicon.ico") || path.startsWith("/api/v1/admin/logs");
+        // SSE 스트리밍 요청("/stream")은 ContentCaching 필터를 타지 않도록 예외 처리
+        // 작성자 최원준 / 면접관의 답변이 프론트에만 보이지 않는 현상 수정
+        return path.startsWith("/error") ||
+                path.startsWith("/favicon.ico") ||
+                path.startsWith("/api/v1/admin/logs") ||
+                path.contains("/stream"); // 작성자 최원준
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #212

<br/>

## 작업 내용
- 텍스트 면접 진행 시 면접관의 답변이 빈칸으로 나오던 현상을 수정
- LoggingFilter.java에서 /stream 요청에 예외처리를 하지 않아 응답이 보내지기 전에 연결을 종료하는 것이 원인이었으며 예외 처리 추가하였음

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다

## 연관 이슈
- #
