### PR TITLE
[FIX] sql스키마와 모델의 벡터값이 다른 문제 수정

### DIFF
--- a/db/init/001_init.sql
+++ b/db/init/001_init.sql
@@ -48,7 +48,7 @@ CREATE TABLE resume (
                         title VARCHAR(255) NOT NULL,
                         s3_file_url VARCHAR(500),
                         content TEXT,
-                        embedding VECTOR(384),
+                        embedding VECTOR(768),
                         is_analyzed BOOLEAN DEFAULT FALSE,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -64,7 +64,7 @@ CREATE TABLE job_posting (
                              job_title VARCHAR(100) NOT NULL,
                              posting_url TEXT,
                              job_description TEXT,
-                             embedding VECTOR(384),
+                             embedding VECTOR(768),
                              created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                              updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                              CONSTRAINT fk_job_member


### PR DESCRIPTION
## 관련 이슈
- closed: #214

## 작업 내용
- DB 스키마(`001_init.sql`)의 벡터 컬럼과 엔티티 모델 간 불일치 문제 수정
- 벡터 차원 값(`vector dimension`)을 모델과 동일하게 맞춤

<br/>
## ❗ 문제 상황
- DB: vector(n)
- Entity: embedding dimension 불일치

→ 이로 인해:
- 벡터 저장 시 오류 가능
- 유사도 검색 시 비정상 동작 가능

<br/>
- DB 스키마의 vector dimension을 모델 기준으로 통일

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
