### PR TITLE
[FIX] 로그인 사용자 식별 resolver 개선

### DIFF
--- a/src/main/java/com/aibe/team2/global/common/resolver/LoginMemberIdResolver.java
+++ b/src/main/java/com/aibe/team2/global/common/resolver/LoginMemberIdResolver.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,9 +38,12 @@ public class LoginMemberIdResolver implements HandlerMethodArgumentResolver {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         // 1. 정상적인 인증 토큰이 있는 경우 (가장 이상적)
-        if (authentication != null && authentication.isAuthenticated() && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
-            if (userDetails.getMember() != null) {
-                return userDetails.getMember().getMemberId();
+        if (authentication != null
+                && authentication.isAuthenticated()
+                && !(authentication instanceof AnonymousAuthenticationToken)
+                && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            if (userDetails.getMemberId() != null) {
+                return userDetails.getMemberId();
             }
         }
 


### PR DESCRIPTION
## 관련 이슈
- closed: #218

## 작업 내용
- LoginMemberIdResolver의 로그인 사용자 식별 로직 개선 

## 문제 상황
- 기존 resolver에서 사용자 식별 과정이 불안정하거나 중복 처리 발생 가능

## 개선 사항
- 인증 객체에서 memberId를 명확하게 추출하도록 수정
- CustomUserDetails와 연계하여 일관된 사용자 식별 보장

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다