### PR TITLE
[FIX] 자소서 분석 API 로그인 사용자 식별 반영

### DIFF
--- a/src/main/java/com/aibe/team2/domain/resume/controller/AnalysisController.java
+++ b/src/main/java/com/aibe/team2/domain/resume/controller/AnalysisController.java
@@ -23,8 +23,9 @@ public class AnalysisController {
 
     // 1. 일반 자기소개서 첨삭 요청
     @PostMapping("/{resumeId}/analyze/normal")
-    public ResponseEntity<ApiResponse<Long>> analyzeNormalResume(@PathVariable Long resumeId) {
-        Long memberId = 1L; // 임시 하드코딩 (테스트용)
+    public ResponseEntity<ApiResponse<Long>> analyzeNormalResume(
+            @PathVariable Long resumeId,
+            @LoginMemberId Long memberId) {
         Long reportId = analysisService.requestNormalAnalysis(resumeId, memberId);
         return ResponseEntity.ok(ApiResponse.success(reportId));
     }
@@ -33,8 +34,8 @@ public class AnalysisController {
     @PostMapping("/{resumeId}/analyze/match")
     public ResponseEntity<ApiResponse<Long>> analyzeMatchResume(
             @PathVariable Long resumeId,
-            @RequestBody AnalysisMatchRequest request) {
-        Long memberId = 1L; // 임시 하드코딩 (테스트용)
+            @RequestBody AnalysisMatchRequest request,
+            @LoginMemberId Long memberId) {
         Long reportId = analysisService.requestMatchAnalysis(resumeId, memberId, request.jobPostingId());
         return ResponseEntity.ok(ApiResponse.success(reportId));
     }
@@ -43,10 +44,10 @@ public class AnalysisController {
     @GetMapping("/{resumeId}/reports/{reportId}")
     public ResponseEntity<ApiResponse<AnalysisResponse>> getAnalysisReport(
             @PathVariable Long resumeId,
-            @PathVariable Long reportId) {
+            @PathVariable Long reportId,
+            @LoginMemberId Long memberId) {
 
         log.info("자기소개서 ID: {} 에 대한 분석 결과 원본 상세 조회 요청 - 리포트 ID: {}", resumeId, reportId);
-        Long memberId = 1L; // 임시 하드코딩
         AnalysisResponse response = analysisService.getAnalysisResult(resumeId, reportId, memberId);
 
         return ResponseEntity.ok(ApiResponse.success(response));


### PR DESCRIPTION
## 관련 이슈
- closed: #220

## 작업 내용
- 자소서 분석 API에서 로그인 사용자 식별 정보를 반영하도록 수정
- AnalysisController에서 인증 사용자 기준으로 요청을 처리하도록 개선

<br/>
## 문제 상황
- 기존에는 로그인 사용자 식별이 명확히 연결되지 않아
  요청 사용자 기준 처리가 누락될 수 있었음

## 개선 사항
- resolver를 통해 전달받은 로그인 사용자 식별값을 사용하도록 반영
- 자소서 분석 요청이 인증 사용자 기준으로 일관되게 처리되도록 수정

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다