### PR TITLE
[FIX] role이 응답에 반영되도록 수정

### DIFF
--- a/src/main/java/com/aibe/team2/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/aibe/team2/domain/auth/controller/AuthController.java
@@ -186,6 +186,10 @@ public class AuthController {
 
         // 토큰이 유효하면 유저 정보와 함께 토큰을 JSON으로 반환 (프론트가 저장할 수 있도록)
         String nickname = memberService.getNicknameByEmail(jwtTokenProvider.getEmail(token));
-        return ResponseEntity.ok(ApiResponse.success(new MeResponse(nickname, token)));
+        String role = jwtTokenProvider.getRole(token);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                new MeResponse(nickname, role, token)
+        ));
     }
 }

--- a/src/main/java/com/aibe/team2/domain/auth/dto/MeResponse.java
+++ b/src/main/java/com/aibe/team2/domain/auth/dto/MeResponse.java
@@ -7,5 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MeResponse {
     private String nickname;
+    private String role;
     private String accessToken;
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #226

## 변경 내용
- 사용자 정보 응답(Me API)에 role 필드가 포함되도록 수정

## 문제 상황
- 기존 응답에서 사용자 role 정보가 포함되지 않아
  프론트에서 권한 기반 처리에 어려움 존재

## 개선 사항
- MeResponse에 role 필드 추가
- AuthController에서 role 값을 포함하여 반환하도록 수정

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다