### PR TITLE
[FEAT] 에러 상태 이슈 해결 및 SQL/Enum 동기화

### DIFF
--- a/db/init/001_init.sql
+++ b/db/init/001_init.sql
@@ -316,14 +316,15 @@ CREATE TABLE error_issue (
                              CONSTRAINT chk_error_issue_severity
                                  CHECK (severity IN ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL')),
                              CONSTRAINT chk_error_issue_status
-                                 CHECK (status IN ('OPEN', 'RESOLVED', 'IGNORED')),
+                                 CHECK (status IN ('OPEN', 'IN_PROGRESS', 'RESOLVED', 'IGNORED')),
                              CONSTRAINT chk_error_issue_domain
                                  CHECK (error_domain IN (
-                                                         'COMMON',
+                                                         'GLOBAL',
                                                          'AUTH',
                                                          'RESUME',
                                                          'INTERVIEW',
                                                          'JOB_POSTING',
+                                                         'FILE',
                                                          'STATISTICS',
                                                          'ADMIN',
                                                          'QUEUE',
@@ -371,11 +372,12 @@ CREATE TABLE error_log (
                                CHECK (severity IN ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL')),
                            CONSTRAINT chk_error_log_domain
                                CHECK (error_domain IN (
-                                                       'COMMON',
+                                                       'GLOBAL',
                                                        'AUTH',
                                                        'RESUME',
                                                        'INTERVIEW',
                                                        'JOB_POSTING',
+                                                       'FILE',
                                                        'STATISTICS',
                                                        'ADMIN',
                                                        'QUEUE',

--- a/src/main/java/com/aibe/team2/domain/admin/service/OpsMonitoringService.java
+++ b/src/main/java/com/aibe/team2/domain/admin/service/OpsMonitoringService.java
@@ -43,7 +43,9 @@ public class OpsMonitoringService {
         long totalDone = todayQueueSuccessCount + todayQueueFailedCount;
         double successRate = totalDone == 0 ? 0.0 : (todayQueueSuccessCount * 100.0 / totalDone);
 
-        long unresolvedIssueCount = errorIssueRepository.countByStatus(IssueStatus.OPEN);
+        long unresolvedIssueCount = errorIssueRepository.countByStatusIn(
+                List.of(IssueStatus.OPEN, IssueStatus.IN_PROGRESS)
+        );
 
         return OpsDashboardSummaryResponse.builder()
                 .todayErrorCount(todayErrorCount)
@@ -76,12 +78,15 @@ public class OpsMonitoringService {
                     .build());
         }
 
-        long openIssueCount = errorIssueRepository.countByStatus(IssueStatus.OPEN);
-        if (openIssueCount >= alertThreshold) {
+        long unresolvedIssueCount = errorIssueRepository.countByStatusIn(
+                List.of(IssueStatus.OPEN, IssueStatus.IN_PROGRESS)
+        );
+
+        if (unresolvedIssueCount >= alertThreshold) {
             alerts.add(OpsAlertResponse.builder()
-                    .alertType("OPEN_ERROR_ISSUE")
+                    .alertType("UNRESOLVED_ERROR_ISSUE")
                     .severity("MEDIUM")
-                    .message("미해결 에러 이슈가 임계치 이상입니다. openIssueCount=" + openIssueCount)
+                    .message("미해결 에러 이슈가 임계치 이상입니다. unresolvedIssueCount=" + unresolvedIssueCount)
                     .targetType("ERROR_ISSUE")
                     .targetId(null)
                     .build());

--- a/src/main/java/com/aibe/team2/domain/error/controller/ErrorIssueAdminController.java
+++ b/src/main/java/com/aibe/team2/domain/error/controller/ErrorIssueAdminController.java
@@ -1,0 +1,28 @@
+package com.aibe.team2.domain.error.controller;
+
+import com.aibe.team2.domain.error.dto.admin.ErrorIssueStatusUpdateRequest;
+import com.aibe.team2.domain.error.service.ErrorIssueService;
+import com.aibe.team2.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@PreAuthorize("hasRole('ADMIN')")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/error-issues")
+public class ErrorIssueAdminController {
+
+    private final ErrorIssueService errorIssueService;
+
+    @PatchMapping("/{issueId}/status")
+    public ResponseEntity<ApiResponse<Void>> updateIssueStatus(
+            @PathVariable Long issueId,
+            @RequestBody @Valid ErrorIssueStatusUpdateRequest request
+    ) {
+        errorIssueService.updateIssueStatus(issueId, request.getStatus());
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/src/main/java/com/aibe/team2/domain/error/dto/admin/ErrorIssueStatusUpdateRequest.java
+++ b/src/main/java/com/aibe/team2/domain/error/dto/admin/ErrorIssueStatusUpdateRequest.java
@@ -3,8 +3,10 @@ package com.aibe.team2.domain.error.dto.admin;
 import com.aibe.team2.domain.error.enums.IssueStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ErrorIssueStatusUpdateRequest {
 
     @NotNull

--- a/src/main/java/com/aibe/team2/domain/error/enums/ErrorDomain.java
+++ b/src/main/java/com/aibe/team2/domain/error/enums/ErrorDomain.java
@@ -1,11 +1,15 @@
 package com.aibe.team2.domain.error.enums;
 
 public enum ErrorDomain {
+    GLOBAL,
     AUTH,
     RESUME,
     INTERVIEW,
+    JOB_POSTING,
     FILE,
-    ADMIN,
     STATISTICS,
-    GLOBAL
+    ADMIN,
+    QUEUE,
+    EXTERNAL_API,
+    SYSTEM
 }

--- a/src/main/java/com/aibe/team2/domain/error/enums/IssueStatus.java
+++ b/src/main/java/com/aibe/team2/domain/error/enums/IssueStatus.java
@@ -3,5 +3,6 @@ package com.aibe.team2.domain.error.enums;
 public enum IssueStatus {
     OPEN,
     IN_PROGRESS,
-    RESOLVED
+    RESOLVED,
+    IGNORED
 }

--- a/src/main/java/com/aibe/team2/domain/error/repository/ErrorIssueRepository.java
+++ b/src/main/java/com/aibe/team2/domain/error/repository/ErrorIssueRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.Optional;
 
 public interface ErrorIssueRepository extends JpaRepository<ErrorIssue, Long>, ErrorIssueRepositoryCustom {
@@ -34,4 +35,6 @@ public interface ErrorIssueRepository extends JpaRepository<ErrorIssue, Long>, E
     );
 
     long countByStatus(IssueStatus status);
+
+    long countByStatusIn(Collection<IssueStatus> statuses);
 }

--- a/src/main/java/com/aibe/team2/domain/error/service/ErrorIssueService.java
+++ b/src/main/java/com/aibe/team2/domain/error/service/ErrorIssueService.java
@@ -4,7 +4,10 @@ import com.aibe.team2.domain.error.config.ErrorAlertProperties;
 import com.aibe.team2.domain.error.entity.ErrorIssue;
 import com.aibe.team2.domain.error.enums.ErrorDomain;
 import com.aibe.team2.domain.error.enums.ErrorSeverity;
+import com.aibe.team2.domain.error.enums.IssueStatus;
 import com.aibe.team2.domain.error.repository.ErrorIssueRepository;
+import com.aibe.team2.global.error.ErrorCode;
+import com.aibe.team2.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -69,6 +72,13 @@ public class ErrorIssueService {
     public void increaseOccurrence(ErrorIssue issue, LocalDateTime occurredAt, Long errorLogId) {
         issue.increaseOccurrence(occurredAt, errorLogId);
         checkAlertThreshold(issue);
+    }
+
+    public void updateIssueStatus(Long issueId, IssueStatus status) {
+        ErrorIssue issue = errorIssueRepository.findById(issueId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ERROR_ISSUE_NOT_FOUND));
+
+        issue.updateStatus(status);
     }
 
     private void checkAlertThreshold(ErrorIssue issue) {

--- a/src/main/java/com/aibe/team2/global/error/ErrorCode.java
+++ b/src/main/java/com/aibe/team2/global/error/ErrorCode.java
@@ -120,7 +120,10 @@ public enum ErrorCode {
     REDIS_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_001", "캐시 서버(Redis) 연결에 실패했습니다."),
     REDIS_OPERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_002", "캐시 서버(Redis) 데이터 읽기/쓰기 작업 중 오류가 발생했습니다."),
     REDIS_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "REDIS_003", "캐시 서버(Redis) 응답 시간이 초과되었습니다."),
-    REDIS_SERIALIZATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_004", "캐시 서버(Redis) 데이터를 직렬화/역직렬화하는 중 오류가 발생했습니다.");
+    REDIS_SERIALIZATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS_004", "캐시 서버(Redis) 데이터를 직렬화/역직렬화하는 중 오류가 발생했습니다."),
+
+    // Error Issue (에러 이슈)
+    ERROR_ISSUE_NOT_FOUND(HttpStatus.NOT_FOUND, "ERROR_001", "에러 이슈를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 관련 이슈
- closed: #230

## 작업 내용
### 1. Error Issue 상태 체계 개선
- IssueStatus에 `IN_PROGRESS`, `IGNORED` 추가
- 상태 변경 API (`PATCH /admin/error-issues/{id}/status`) 구현

### 2. SQL / Enum 정합성 통일
- `error_issue.status`, `error_domain` CHECK 제약 조건 수정
- Java enum과 DB 스키마 완전 일치하도록 정리

### 3. 에러 이슈 상태 변경 기능 추가
- ErrorIssueAdminController 추가
- ErrorIssueService에 상태 변경 로직 추가

### 4. 모니터링 기준 개선
- 미해결 이슈 기준을 `OPEN + IN_PROGRESS`로 변경
- OpsMonitoringService 로직 수정

### 5. 에러 코드 개선
- `ERROR_ISSUE_NOT_FOUND` 추가
<br/>


## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다