### PR TITLE
[FEAT] 에러 ui 관련 코드 추가

### DIFF
--- a/src/main/java/com/aibe/team2/domain/error/controller/ErrorAdminController.java
+++ b/src/main/java/com/aibe/team2/domain/error/controller/ErrorAdminController.java
@@ -8,6 +8,7 @@ import com.aibe.team2.domain.error.dto.admin.ErrorLogDetailResponse;
 import com.aibe.team2.domain.error.dto.admin.ErrorLogRowResponse;
 import com.aibe.team2.domain.error.enums.IssueStatus;
 import com.aibe.team2.domain.error.service.ErrorAdminService;
+import com.aibe.team2.domain.error.service.ErrorIssueService;
 import com.aibe.team2.global.common.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class ErrorAdminController {
 
     private final ErrorAdminService errorAdminService;
+    private final ErrorIssueService errorIssueService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<Page<ErrorIssueResponse>>> searchIssues(
@@ -68,8 +70,7 @@ public class ErrorAdminController {
             @PathVariable Long issueId,
             @RequestBody @Valid ErrorIssueStatusUpdateRequest request
     ) {
-        return ResponseEntity.ok(ApiResponse.success(
-                errorAdminService.updateIssueStatus(issueId, request.getStatus())
-        ));
+        errorIssueService.updateIssueStatus(issueId, request.getStatus());
+        return ResponseEntity.ok(ApiResponse.success(request.getStatus()));
     }
 }

--- a/src/main/java/com/aibe/team2/domain/error/dto/admin/ErrorIssueResponse.java
+++ b/src/main/java/com/aibe/team2/domain/error/dto/admin/ErrorIssueResponse.java
@@ -25,7 +25,14 @@ public class ErrorIssueResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public ErrorIssueResponse(ErrorIssue issue) {
+    private final String statusHint;
+    private final boolean recentlyOccurred;
+
+    public ErrorIssueResponse(
+            ErrorIssue issue,
+            String statusHint,
+            boolean recentlyOccurred
+    ) {
         this.issueId = issue.getId();
         this.fingerprint = issue.getFingerprint();
         this.title = issue.getTitle();
@@ -39,5 +46,7 @@ public class ErrorIssueResponse {
         this.lastErrorLogId = issue.getLastErrorLogId();
         this.createdAt = issue.getCreatedAt();
         this.updatedAt = issue.getUpdatedAt();
+        this.statusHint = statusHint;
+        this.recentlyOccurred = recentlyOccurred;
     }
 }

--- a/src/main/java/com/aibe/team2/domain/error/service/ErrorAdminService.java
+++ b/src/main/java/com/aibe/team2/domain/error/service/ErrorAdminService.java
@@ -1,13 +1,8 @@
 package com.aibe.team2.domain.error.service;
 
-import com.aibe.team2.domain.error.dto.admin.ErrorIssueDetailResponse;
-import com.aibe.team2.domain.error.dto.admin.ErrorIssueResponse;
-import com.aibe.team2.domain.error.dto.admin.ErrorIssueSearchCond;
-import com.aibe.team2.domain.error.dto.admin.ErrorLogDetailResponse;
-import com.aibe.team2.domain.error.dto.admin.ErrorLogRowResponse;
+import com.aibe.team2.domain.error.dto.admin.*;
 import com.aibe.team2.domain.error.entity.ErrorIssue;
 import com.aibe.team2.domain.error.entity.ErrorLog;
-import com.aibe.team2.domain.error.enums.IssueStatus;
 import com.aibe.team2.domain.error.repository.ErrorIssueRepository;
 import com.aibe.team2.domain.error.repository.ErrorLogRepository;
 import com.aibe.team2.domain.mypage.entity.Member;
@@ -19,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -27,14 +24,40 @@ public class ErrorAdminService {
     private final ErrorIssueRepository errorIssueRepository;
     private final ErrorLogRepository errorLogRepository;
 
+    private String buildStatusHint(LocalDateTime lastOccurredAt) {
+        if (lastOccurredAt == null) {
+            return "발생 이력 없음";
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (lastOccurredAt.isAfter(now.minusHours(24))) {
+            return "최근 24시간 내 재발";
+        }
+
+        if (lastOccurredAt.isAfter(now.minusDays(3))) {
+            return "최근 3일 내 발생";
+        }
+
+        return "최근 3일 미발생";
+    }
+
+    private boolean isRecentlyOccurred(LocalDateTime lastOccurredAt) {
+        return lastOccurredAt != null && lastOccurredAt.isAfter(LocalDateTime.now().minusHours(24));
+    }
+
     public Page<ErrorIssueResponse> searchIssues(ErrorIssueSearchCond cond, Pageable pageable) {
         return errorIssueRepository.search(cond, pageable)
-                .map(ErrorIssueResponse::new);
+                .map(issue -> new ErrorIssueResponse(
+                        issue,
+                        buildStatusHint(issue.getLastOccurredAt()),
+                        isRecentlyOccurred(issue.getLastOccurredAt())
+                ));
     }
 
     public ErrorIssueDetailResponse getIssueDetail(Long issueId) {
         ErrorIssue issue = errorIssueRepository.findById(issueId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMON_404));
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ERROR_ISSUE_NOT_FOUND));
 
         ErrorLog latestLog = errorLogRepository.findTopByIssueIdOrderByOccurredAtDesc(issueId)
                 .orElse(null);
@@ -75,15 +98,6 @@ public class ErrorAdminService {
     public ErrorLogDetailResponse getLogDetail(Long logId) {
         return errorLogRepository.findById(logId)
                 .map(ErrorLogDetailResponse::new)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMON_404));
-    }
-
-    @Transactional
-    public IssueStatus updateIssueStatus(Long issueId, IssueStatus status) {
-        ErrorIssue issue = errorIssueRepository.findById(issueId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.COMMON_404));
-
-        issue.updateStatus(status);
-        return issue.getStatus();
+                .orElseThrow(() -> new NotFoundException(ErrorCode.ERROR_ISSUE_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closed: #233

## 작업 내용
- 에러 이슈 상태 변경 API 연동
- ErrorIssueResponse에 보조 정보(statusHint, recentlyOccurred) 추가
- 에러 이슈 조회 시 상태 힌트 로직 적용
- ErrorCode COMMON_404 → ERROR_ISSUE_NOT_FOUND로 정리

## 목적
- 에러 관제 UI에서 상태 관리 기능 지원
- 운영자가 이슈 상태를 직접 관리할 수 있도록 개선

## 변경 사항
- ErrorAdminController: 상태 변경 API 수정 (ErrorIssueService 사용)
- ErrorAdminService: 상태 힌트 로직 추가 및 에러 코드 수정
- ErrorIssueResponse: UI 보조 필드 추가

<br/>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
