### PR TITLE
[FEAT] 면접 설정 화면에 자기소개서/채용공고 항목 추가

### DIFF
--- a/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
+++ b/src/main/java/com/aibe/team2/domain/interview/controller/InterviewController.java
@@ -42,6 +42,7 @@ public class InterviewController {
                     authenticatedMemberId,
                     request.getResumeId(),
                     request.getJobPostingId(),
+                    request.getJobDescription(),
                     InterviewMode.from(request.getInterviewMode()),
                     request.getInterviewType(),
                     request.getAiProvider(),
@@ -58,7 +59,7 @@ public class InterviewController {
             @PathVariable Long sessionId,
             @RequestParam String answer,
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam(required = false) Long memberId, // 🚀 복구: 프론트엔드 연동 및 SSE 한계 우회용
+            @RequestParam(required = false) Long memberId,
             @RequestParam(required = false, defaultValue = "gemini-flash-latest") String modelVariant,
             @RequestParam(required = false, defaultValue = "NORMAL") String interviewMode) {
 
@@ -81,7 +82,7 @@ public class InterviewController {
     public VoiceSessionResponse startVoiceInterview(
             @PathVariable Long sessionId,
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam(required = false) Long memberId) { // 🚀 복구
+            @RequestParam(required = false) Long memberId) {
 
         InterviewSession session = validateAndGetSessionOwnership(sessionId, userDetails, memberId);
 
@@ -96,7 +97,7 @@ public class InterviewController {
     public ResponseEntity<Void> endInterview(
             @PathVariable Long sessionId,
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam(required = false) Long memberId) { // 🚀 복구
+            @RequestParam(required = false) Long memberId) {
 
         validateAndGetSessionOwnership(sessionId, userDetails, memberId);
 
@@ -108,7 +109,7 @@ public class InterviewController {
     public ResponseEntity<InterviewReportResponse> getInterviewReport(
             @PathVariable Long sessionId,
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestParam(required = false) Long memberId) { // 🚀 복구
+            @RequestParam(required = false) Long memberId) {
 
         InterviewSession session = validateAndGetSessionOwnership(sessionId, userDetails, memberId);
 
@@ -120,9 +121,7 @@ public class InterviewController {
         }
     }
 
-    /**
-     * 🚀 보안 리뷰 반영 및 SSE 우회: Security 인증 객체와 fallbackMemberId를 유연하게 처리
-     */
+    //보안 리뷰 반영 및 SSE 우회: Security 인증 객체와 fallbackMemberId를 유연하게 처리
     private InterviewSession validateAndGetSessionOwnership(Long sessionId, UserDetails userDetails, Long fallbackMemberId) {
         Long authenticatedMemberId;
 

--- a/src/main/java/com/aibe/team2/domain/interview/dto/InterviewStartRequest.java
+++ b/src/main/java/com/aibe/team2/domain/interview/dto/InterviewStartRequest.java
@@ -9,6 +9,7 @@ public class InterviewStartRequest {
     private Long memberId;
     private Long resumeId;
     private Long jobPostingId;
+    private String jobDescription;
     private String interviewMode;
     private String interviewType;
     private String aiProvider;

--- a/src/main/java/com/aibe/team2/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/com/aibe/team2/domain/interview/entity/InterviewSession.java
@@ -31,6 +31,9 @@ public class InterviewSession {
 
     private Long jobPostingId;
 
+    @Column(columnDefinition = "TEXT")
+    private String jobDescription;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private InterviewMode interviewMode;
@@ -66,10 +69,11 @@ public class InterviewSession {
     private LocalDateTime updatedAt;
 
     @Builder
-    public InterviewSession(Long memberId, Long resumeId, Long jobPostingId, InterviewMode interviewMode, String interviewType, String aiProvider, String modelVariant) {
+    public InterviewSession(Long memberId, Long resumeId, Long jobPostingId, String jobDescription, InterviewMode interviewMode, String interviewType, String aiProvider, String modelVariant) {
         this.memberId = memberId;
         this.resumeId = resumeId;
         this.jobPostingId = jobPostingId;
+        this.jobDescription = jobDescription;
         this.interviewMode = interviewMode;
         this.interviewType = interviewType;
         this.aiProvider = aiProvider;

--- a/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/ConversationManager.java
@@ -57,9 +57,11 @@ public class ConversationManager {
         }
 
         // [FR-INT-07] 채용 공고 내용 안전하게 조회 및 추출
-        String jobDescription = null;
-        if (session.getJobPostingId() != null) {
-            jobDescription = jobPostingRepository.findByIdAndMemberId(session.getJobPostingId(), session.getMemberId())
+        String jobDescription = session.getJobDescription();
+
+        // 커스텀 텍스트가 없고 기존 공고 ID가 있다면 DB에서 찾아오기
+        if (jobDescription == null && session.getJobPostingId() != null) {
+            jobDescription = jobPostingRepository.findById(session.getJobPostingId())
                     .map(JobPosting::getJobDescription)
                     .orElse(null);
         }

--- a/src/main/java/com/aibe/team2/domain/interview/service/GeminiService.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/GeminiService.java
@@ -37,6 +37,12 @@ public class GeminiService {
     }
 
     public Flux<String> streamQuestion(String sessionId, InterviewRequestDto request) {
+        log.info("=================================================");
+        log.info("👀 [디버그] 전달받은 자기소개서 본문:\n{}",
+                request.getResumeContent() != null ? request.getResumeContent() : "없음 (선택 안함)");
+        log.info("👀 [디버그] 전달받은 채용 공고 본문:\n{}",
+                request.getJobDescription() != null ? request.getJobDescription() : "없음 (선택 안함)");
+        log.info("=================================================");
         String rootUrl = baseUrl.split("/v1")[0];
         if (rootUrl.endsWith("/")) rootUrl = rootUrl.substring(0, rootUrl.length() - 1);
 
@@ -60,7 +66,7 @@ public class GeminiService {
             jobContext = "\n\n[Job Posting Requirements]\n다음은 지원자가 지원한 채용 공고의 상세 내용(요구 역량 및 주요 업무)입니다. 이를 바탕으로 직무 적합성을 검증하는 질문을 생성하세요.\n" + request.getJobDescription();
         }
 
-        // 🚀 보안 리뷰 반영 (Prompt Injection 방어):
+        // 보안 리뷰 반영 (Prompt Injection 방어):
         // 1. AI가 절대적으로 따라야 할 시스템 지시사항 (분위기, 이력서, 공고, 제약조건)
         String systemPrompt = String.format("%s%s%s\n\n%s",
                 atmospherePrompt, resumeContext, jobContext, constraints);
@@ -70,7 +76,7 @@ public class GeminiService {
 
         log.info("[Gemini-Streaming] Session: {}, Mode: {}", sessionId, request.getInterviewMode());
 
-        // 🚀 JSON Payload 조립 시 systemInstruction 속성을 명시적으로 분리하여 전송
+        // JSON Payload 조립 시 systemInstruction 속성을 명시적으로 분리하여 전송
         Map<String, Object> requestBody = Map.of(
                 "systemInstruction", Map.of(
                         "parts", List.of(Map.of("text", systemPrompt))
@@ -80,6 +86,11 @@ public class GeminiService {
                                 "parts", List.of(Map.of("text", userMessage)))
                 )
         );
+
+        // [디버그용 로그 추가] Gemini API로 날아가기 직전의 최종 캡슐(JSON) 확인
+        log.info("[디버그] 제미나이에게 전송되는 최종 Payload (JSON)");
+        log.info("{}", requestBody);
+        log.info("=======================================================================");
 
         return webClient.post()
                 .uri(URI.create(fullUrl))

--- a/src/main/java/com/aibe/team2/domain/interview/service/InterviewManager.java
+++ b/src/main/java/com/aibe/team2/domain/interview/service/InterviewManager.java
@@ -19,13 +19,15 @@ public class InterviewManager {
 
     @Transactional
     // @DistributedLock(key = "interview-start", waitTime = 1, leaseTime = 3)
-    public InterviewSession startInterview(Long memberId, Long resumeId, Long jobPostingId,
+    public InterviewSession startInterview(Long memberId, Long resumeId,
+                                           Long jobPostingId, String jobDescription,
                                            InterviewMode interviewMode, String interviewType,
                                            String aiProvider, String modelVariant) {
         InterviewSession session = InterviewSession.builder()
                 .memberId(memberId)
                 .resumeId(resumeId)
                 .jobPostingId(jobPostingId)
+                .jobDescription(jobDescription)
                 .interviewMode(interviewMode)
                 .interviewType(interviewType)
                 .aiProvider(aiProvider)

--- a/src/main/java/com/aibe/team2/domain/resume/service/AnalysisService.java
+++ b/src/main/java/com/aibe/team2/domain/resume/service/AnalysisService.java
@@ -65,7 +65,7 @@ public class AnalysisService {
                 .resume(resume)
                 .analysisType(AnalysisType.NORMAL)
                 .jobPosting(null)
-                .jobDescriptionText(null) // 🚀 일반 첨삭은 공고가 없으므로 null 전달
+                .jobDescriptionText(null) // 일반 첨삭은 공고가 없으므로 null 전달
                 .build();
 
         resumeAnalysisRepository.save(report);
@@ -87,7 +87,7 @@ public class AnalysisService {
             throw new BusinessException(ErrorCode.COMMON_403);
         }
 
-        // 🚀 더 이상 DB에서 JobPosting을 조회하지 않습니다. 파라미터로 받은 텍스트를 그대로 저장합니다.
+        // DB에서 JobPosting을 조회하지 않고 파라미터로 받은 텍스트를 그대로 저장
         AnalyzedReport report = AnalyzedReport.builder()
                 .resume(resume)
                 .analysisType(AnalysisType.FIT_MATCH)


### PR DESCRIPTION
## 작업 내용
- 면접 설정 페이지 pages/interview/SetupPage.jsx에 자신이 작성한 자기소개서, 채용 공고 링크를 복사하여 채용 공고 요약 기능을 추가했습니다.
- 면접 설정 페이지 pages/interview/SetupPage.jsx에서 음성 면접을 선택하는 경우 옵션 선택 박스를 숨김처리 하도록 로직을 추가했습니다.

<br>

## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [ ] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다
