### PR TITLE
[FEAT] Grafana 로그 관제 적용 및 초기 스키마 동기화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ localstack/
 # IDE의 자체 빌더가 src/main/generated에 생성할 경우 대비
 /src/main/generated
 
-# 모든 application 관련 설정 파일 제외
-# *-dev.*
-
 # 로그파일 제외
 *.log
 

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,11 @@ dependencies {
     implementation "software.amazon.awssdk:auth"
 
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs:3.1.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    implementation 'com.github.loki4j:loki-logback-appender:1.5.2'
 }
 
 // Q-Class

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -49,11 +49,16 @@ services:
 
       REDIS_HOST: redis
       REDIS_PORT: 6379
+
+      LOG_ENV: prod
+      LOKI_URL: http://loki:3100/loki/api/v1/push
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
+      loki:
+        condition: service_started
 
   nginx:
     image: nginx:1.25.4
@@ -68,6 +73,28 @@ services:
     depends_on:
       - app
 
+  loki:
+    image: grafana/loki:2.9.0
+    container_name: loki
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    image: grafana/grafana:10.2.0
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - loki
+
 volumes:
   pgdata:
   redis_data:
+  grafana_data:

--- a/db/init/001_init.sql
+++ b/db/init/001_init.sql
@@ -22,6 +22,7 @@ CREATE TABLE member (
                         profile_image_url VARCHAR(500),
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        last_login_at TIMESTAMP DEFAULT NULL,
                         deleted_at TIMESTAMP DEFAULT NULL,
                         status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE'
                             CHECK (status IN ('ACTIVE', 'DORMANCY', 'DELETED'))

--- a/src/main/java/com/aibe/team2/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/aibe/team2/domain/admin/service/AdminDashboardService.java
@@ -28,7 +28,7 @@ public class AdminDashboardService {
         LocalDateTime end = today.plusDays(1).atStartOfDay();
 
         Long activeMemberCount = memberRepository.countByStatus(MemberStatus.ACTIVE);
-        Long dormancyMemberCount = memberRepository.countByStatus(MemberStatus.DORMANCY);
+        Long dormancyMemberCount = memberRepository.countByStatus(MemberStatus.DORMANT);
         Long deletedMemberCount = memberRepository.countByStatus(MemberStatus.DELETED);
 
         Long todayUsageLogCount = usageLogRepository.countByCreatedAtBetween(start, end);

--- a/src/main/java/com/aibe/team2/domain/admin/service/QueueJobMetricService.java
+++ b/src/main/java/com/aibe/team2/domain/admin/service/QueueJobMetricService.java
@@ -4,6 +4,7 @@ import com.aibe.team2.domain.admin.entity.QueueJobMetric;
 import com.aibe.team2.domain.admin.enums.QueueJobStatus;
 import com.aibe.team2.domain.admin.enums.QueueJobType;
 import com.aibe.team2.domain.admin.repository.QueueJobMetricRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QueueJobMetricService {
 
     private final QueueJobMetricRepository queueJobMetricRepository;
+    private final MeterRegistry meterRegistry;
 
     @Transactional
     public Long recordEnqueued(
@@ -32,7 +34,14 @@ public class QueueJobMetricService {
                 messageId,
                 retryCount
         );
-        return queueJobMetricRepository.save(metric).getId();
+        Long savedId = queueJobMetricRepository.save(metric).getId();
+
+        meterRegistry.counter("queue.job.enqueued",
+                "jobType", jobType.name(),
+                "targetType", targetType
+        ).increment();
+
+        return savedId;
     }
 
     @Transactional
@@ -43,20 +52,35 @@ public class QueueJobMetricService {
 
     @Transactional
     public void markSuccess(Long queueJobMetricId) {
-        queueJobMetricRepository.findById(queueJobMetricId)
-                .ifPresent(QueueJobMetric::markSuccess);
+        queueJobMetricRepository.findById(queueJobMetricId).ifPresent(metric -> {
+            metric.markSuccess();
+            meterRegistry.counter("queue.job.success",
+                    "jobType", metric.getJobType().name(),
+                    "targetType", metric.getTargetType()
+            ).increment();
+        });
     }
 
     @Transactional
     public void markFailed(Long queueJobMetricId, String errorMessage) {
-        queueJobMetricRepository.findById(queueJobMetricId)
-                .ifPresent(metric -> metric.markFailed(trim(errorMessage)));
+        queueJobMetricRepository.findById(queueJobMetricId).ifPresent(metric -> {
+            metric.markFailed(trim(errorMessage));
+            meterRegistry.counter("queue.job.failed",
+                    "jobType", metric.getJobType().name(),
+                    "targetType", metric.getTargetType()
+            ).increment();
+        });
     }
 
     @Transactional
     public void markRetried(Long queueJobMetricId) {
-        queueJobMetricRepository.findById(queueJobMetricId)
-                .ifPresent(QueueJobMetric::markRetried);
+        queueJobMetricRepository.findById(queueJobMetricId).ifPresent(metric -> {
+            metric.markRetried();
+            meterRegistry.counter("queue.job.retried",
+                    "jobType", metric.getJobType().name(),
+                    "targetType", metric.getTargetType()
+            ).increment();
+        });
     }
 
     private String trim(String value) {

--- a/src/main/java/com/aibe/team2/domain/error/service/ErrorLogService.java
+++ b/src/main/java/com/aibe/team2/domain/error/service/ErrorLogService.java
@@ -8,8 +8,10 @@ import com.aibe.team2.domain.error.repository.ErrorLogRepository;
 import com.aibe.team2.domain.error.util.ErrorFingerprintGenerator;
 import com.aibe.team2.domain.error.util.ErrorSeverityResolver;
 import com.aibe.team2.domain.mypage.entity.Member;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.MDC;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +31,10 @@ public class ErrorLogService {
     private final ErrorIssueService errorIssueService;
     private final ErrorFingerprintGenerator fingerprintGenerator;
     private final ErrorSeverityResolver severityResolver;
+    private final MeterRegistry meterRegistry;
 
+    @Async("errorLogExecutor")
+    @Transactional
     public void record(
             String errorCode,
             ErrorDomain errorDomain,
@@ -93,6 +98,11 @@ public class ErrorLogService {
         );
 
         errorIssueService.increaseOccurrence(issue, occurredAt, errorLog.getId());
+
+        meterRegistry.counter("error.log.count",
+                "domain", errorDomain.name(),
+                "severity", severity.name()
+        ).increment();
     }
 
     private String resolveTraceId() {
@@ -104,7 +114,6 @@ public class ErrorLogService {
         if (throwable == null) {
             return null;
         }
-
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         throwable.printStackTrace(pw);

--- a/src/main/java/com/aibe/team2/global/config/AsyncConfig.java
+++ b/src/main/java/com/aibe/team2/global/config/AsyncConfig.java
@@ -1,10 +1,12 @@
 package com.aibe.team2.global.config;
 
+import org.slf4j.MDC;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -30,6 +32,31 @@ public class AsyncConfig {
 
         // 5. 거절 정책 (RejectedExecutionHandler)
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "errorLogExecutor")
+    public Executor errorLogExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("error-log-");
+
+        // MDC(requestId)를 비동기 스레드에도 전파
+        executor.setTaskDecorator(runnable -> {
+            Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+            return () -> {
+                if (mdcContext != null) MDC.setContextMap(mdcContext);
+                try {
+                    runnable.run();
+                } finally {
+                    MDC.clear();
+                }
+            };
+        });
 
         executor.initialize();
         return executor;

--- a/src/main/java/com/aibe/team2/global/filter/RequestTraceFilter.java
+++ b/src/main/java/com/aibe/team2/global/filter/RequestTraceFilter.java
@@ -1,0 +1,64 @@
+package com.aibe.team2.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestTraceFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(RequestTraceFilter.class);
+
+    private static final String TRACE_ID_KEY = "trace_id";
+    private static final String TRACE_ID_HEADER = "X-Request-ID";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String traceId = Optional
+                .ofNullable(request.getHeader(TRACE_ID_HEADER))
+                .filter(id -> !id.isBlank())
+                .orElse(UUID.randomUUID().toString());
+
+        MDC.put(TRACE_ID_KEY, traceId);
+        MDC.put("method", request.getMethod());
+        MDC.put("uri", request.getRequestURI());
+
+        response.setHeader(TRACE_ID_HEADER, traceId);
+
+        long start = System.currentTimeMillis();
+
+        try {
+            log.info("HTTP 요청 시작");
+
+            filterChain.doFilter(request, response);
+
+            long duration = System.currentTimeMillis() - start;
+            log.info("HTTP 요청 종료 status={} durationMs={}", response.getStatus(), duration);
+
+        } catch (Exception e) {
+            long duration = System.currentTimeMillis() - start;
+            log.error("HTTP 요청 실패 status={} durationMs={}", response.getStatus(), duration, e);
+            throw e;
+        } finally {
+            MDC.remove("trace_id");
+            MDC.remove("method");
+            MDC.remove("uri");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,9 @@ management:
     web:
       exposure:
         include: health,info
+  endpoint:
+    prometheus:
+      enabled: true
   health:
     redis:
       enabled: false

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp>
+                    <fieldName>timestamp</fieldName>
+                    <pattern>yyyy-MM-dd HH:mm:ss.SSS</pattern>
+                </timestamp>
+                <pattern>
+                    <pattern>
+                        {
+                        "level":"%level",
+                        "thread":"%thread",
+                        "logger":"%logger{36}",
+                        "trace_id":"%X{trace_id:-}",
+                        "method":"%X{method:-}",
+                        "uri":"%X{uri:-}",
+                        "message":"%message"
+                        }
+                    </pattern>
+                </pattern>
+                <stackTrace>
+                    <fieldName>stack_trace</fieldName>
+                </stackTrace>
+            </providers>
+        </encoder>
+    </appender>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+            <connectionTimeoutMs>5000</connectionTimeoutMs>
+            <requestTimeoutMs>5000</requestTimeoutMs>
+        </http>
+
+        <format>
+            <label>
+                <pattern>app=team2,env=local</pattern>
+            </label>
+            <message>
+                <pattern>
+                    {
+                    "timestamp":"%date{yyyy-MM-dd HH:mm:ss.SSS}",
+                    "level":"%level",
+                    "thread":"%thread",
+                    "logger":"%logger{36}",
+                    "trace_id":"%X{trace_id:-}",
+                    "method":"%X{method:-}",
+                    "uri":"%X{uri:-}",
+                    "message":"%message"
+                    }
+                </pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+
+        <noPrettyRequestBody>true</noPrettyRequestBody>
+    </appender>
+
+    <logger name="com.github.loki4j" level="WARN" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
<!-- 제목 예시: [feat] 관리자 페이지 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 관련 이슈
- closed: #256

## 작업 내용
### 1. Grafana / Loki 로그 관제 적용
- Loki + Grafana 연동
- JSON 로그 포맷 적용
- trace_id 기반 요청 추적 필터 추가
- 운영 compose에 loki / grafana 반영

### 2. 운영 환경 설정
- `LOG_ENV`, `LOKI_URL` 환경 변수 반영
- 배포 환경에서 prod 로그 분리 가능하도록 수정

### 3. 초기 스키마 동기화
- `member.last_login_at` 컬럼을 `db/init/001_init.sql`에 반영
- 운영 DB에는 이미 존재하여 초기 스키마와 맞추는 작업 수행
## 체크 리스트
- [x] PR 제목 규칙을 준수했습니다
- [x] 관련 이슈를 연결했습니다
- [x] 본문 내용을 명확하게 작성했습니다
- [x] 정상 작동을 로컬 환경에서 검증했습니다