### PR TITLE
[FIX] MemberStatus DORMANT를 DORMANCY 통일

### DIFF
--- a/src/main/java/com/aibe/team2/domain/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/aibe/team2/domain/admin/service/AdminDashboardService.java
@@ -28,7 +28,7 @@ public class AdminDashboardService {
         LocalDateTime end = today.plusDays(1).atStartOfDay();
 
         Long activeMemberCount = memberRepository.countByStatus(MemberStatus.ACTIVE);
-        Long dormancyMemberCount = memberRepository.countByStatus(MemberStatus.DORMANT);
+        Long dormancyMemberCount = memberRepository.countByStatus(MemberStatus.DORMANCY;
         Long deletedMemberCount = memberRepository.countByStatus(MemberStatus.DELETED);
 
         Long todayUsageLogCount = usageLogRepository.countByCreatedAtBetween(start, end);

--- a/src/main/java/com/aibe/team2/domain/auth/service/DormantBatchService.java
+++ b/src/main/java/com/aibe/team2/domain/auth/service/DormantBatchService.java
@@ -36,7 +36,7 @@ public class DormantBatchService {
 
         for (Member member : targetMembers) {
             // 1. 상태 변경
-            member.updateStatus(MemberStatus.DORMANT);
+            member.updateStatus(MemberStatus.DORMANCY);
 
             // 2. 메일 발송
             String html = createDormantNotificationHtml(member.getNickname());

--- a/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/Member.java
@@ -126,7 +126,7 @@ public class Member {
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();
         // 만약 휴면 상태였다가 로그인한 것이라면 ACTIVE로 변경
-        if (this.status == MemberStatus.DORMANT) {
+        if (this.status == MemberStatus.DORMANCY) {
             this.status = MemberStatus.ACTIVE;
         }
     }

--- a/src/main/java/com/aibe/team2/domain/mypage/entity/enums/MemberStatus.java
+++ b/src/main/java/com/aibe/team2/domain/mypage/entity/enums/MemberStatus.java
@@ -2,6 +2,6 @@ package com.aibe.team2.domain.mypage.entity.enums;
 
 public enum MemberStatus {
     ACTIVE,
-    DORMANT,
+    DORMANCY,
     DELETED
 }


### PR DESCRIPTION
<!-- 제목 예시: [feat] 관리자 페이지 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->

## 관련 이슈
- closed: #262

## 작업 내용
- MemberStatus enum에서 DORMANT → DORMANCY로 통일
- DB CHECK constraint와 코드 간 불일치 해결
